### PR TITLE
WIP - 3rd party signup signin

### DIFF
--- a/unify-front-end/app.json
+++ b/unify-front-end/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "myapp",
+    "scheme": "exp://172.29.182.205:8081",
     "newArchEnabled": true,
     "userInterfaceStyle": "automatic",
     "splash": {

--- a/unify-front-end/app.json
+++ b/unify-front-end/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": "exp://172.29.182.205:8081",
+    "scheme": "myapp",
     "newArchEnabled": true,
     "userInterfaceStyle": "automatic",
     "splash": {

--- a/unify-front-end/components/AuthComponents/AuthWrapper.tsx
+++ b/unify-front-end/components/AuthComponents/AuthWrapper.tsx
@@ -67,10 +67,10 @@ export default function AuthWrapper({ children }: Props) {
         />
       );
     }
-    
+
     return showSignUp ? (
-      <SignUp 
-        onSwitchToSignIn={() => setShowSignUp(false)} 
+      <SignUp
+        onSwitchToSignIn={() => setShowSignUp(false)}
         onShowOTP={handleShowOTP}
       />
     ) : (

--- a/unify-front-end/components/AuthComponents/AuthWrapper.tsx
+++ b/unify-front-end/components/AuthComponents/AuthWrapper.tsx
@@ -34,21 +34,17 @@ export default function AuthWrapper({ children }: Props) {
   }, []);
 
   const handleShowOTP = (email: string, password: string) => {
-    console.log('Showing OTP screen for:', email);
     setOtpEmail(email);
     setOtpPassword(password);
     setShowOTP(true);
   };
 
   const handleVerificationSuccess = () => {
-    console.log('OTP verification successful, hiding OTP screen');
     setShowOTP(false);
     setShowSignUp(false);
-    // User is now authenticated and session will be updated
   };
 
   const handleBackToSignUp = () => {
-    console.log('User going back to signup');
     setShowOTP(false);
   };
 
@@ -60,8 +56,6 @@ export default function AuthWrapper({ children }: Props) {
     );
   }
 
-  console.log(session);
-  
   if (!session) {
     if (showOTP) {
       return (

--- a/unify-front-end/components/AuthComponents/AuthWrapper.tsx
+++ b/unify-front-end/components/AuthComponents/AuthWrapper.tsx
@@ -4,6 +4,7 @@ import { Session } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabase';
 import { SignIn } from './SignIn';
 import { SignUp } from './SignUp';
+import OTPVerification from './OTPConfirmation';
 
 type Props = {
   children: React.ReactNode;
@@ -13,6 +14,9 @@ export default function AuthWrapper({ children }: Props) {
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
   const [showSignUp, setShowSignUp] = useState(false);
+  const [showOTP, setShowOTP] = useState(false);
+  const [otpEmail, setOtpEmail] = useState('');
+  const [otpPassword, setOtpPassword] = useState('');
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
@@ -29,6 +33,25 @@ export default function AuthWrapper({ children }: Props) {
     return () => subscription.unsubscribe();
   }, []);
 
+  const handleShowOTP = (email: string, password: string) => {
+    console.log('Showing OTP screen for:', email);
+    setOtpEmail(email);
+    setOtpPassword(password);
+    setShowOTP(true);
+  };
+
+  const handleVerificationSuccess = () => {
+    console.log('OTP verification successful, hiding OTP screen');
+    setShowOTP(false);
+    setShowSignUp(false);
+    // User is now authenticated and session will be updated
+  };
+
+  const handleBackToSignUp = () => {
+    console.log('User going back to signup');
+    setShowOTP(false);
+  };
+
   if (loading) {
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
@@ -36,10 +59,26 @@ export default function AuthWrapper({ children }: Props) {
       </View>
     );
   }
+
   console.log(session);
+  
   if (!session) {
+    if (showOTP) {
+      return (
+        <OTPVerification
+          email={otpEmail}
+          password={otpPassword}
+          onVerificationSuccess={handleVerificationSuccess}
+          onBackToSignUp={handleBackToSignUp}
+        />
+      );
+    }
+    
     return showSignUp ? (
-      <SignUp onSwitchToSignIn={() => setShowSignUp(false)} />
+      <SignUp 
+        onSwitchToSignIn={() => setShowSignUp(false)} 
+        onShowOTP={handleShowOTP}
+      />
     ) : (
       <SignIn onSwitchToSignUp={() => setShowSignUp(true)} />
     );

--- a/unify-front-end/components/AuthComponents/OTPConfirmation.tsx
+++ b/unify-front-end/components/AuthComponents/OTPConfirmation.tsx
@@ -1,5 +1,12 @@
 import React, { useState, useRef } from 'react';
-import { View, Text, TextInput, TouchableOpacity, StyleSheet, Alert } from 'react-native';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  Alert,
+} from 'react-native';
 import { supabase } from '../../lib/supabase';
 import { MaterialIcons } from '@expo/vector-icons';
 import {
@@ -17,11 +24,11 @@ interface OTPVerificationProps {
   onBackToSignUp?: () => void;
 }
 
-export default function OTPVerification({ 
-  email, 
-  password, 
+export default function OTPVerification({
+  email,
+  password,
   onVerificationSuccess,
-  onBackToSignUp 
+  onBackToSignUp,
 }: OTPVerificationProps) {
   const [otp, setOtp] = useState(['', '', '', '', '', '']);
   const [loading, setLoading] = useState(false);
@@ -32,7 +39,7 @@ export default function OTPVerification({
 
   const handleFullOtpChange = (text: string) => {
     const digitsOnly = text.replace(/[^0-9]/g, '');
-  
+
     const truncated = digitsOnly.slice(0, 6);
     setFullOtp(truncated);
 
@@ -58,7 +65,10 @@ export default function OTPVerification({
     setErrorMessage(null);
 
     try {
-      const { data: { session }, error: verifyError } = await supabase.auth.verifyOtp({
+      const {
+        data: { session },
+        error: verifyError,
+      } = await supabase.auth.verifyOtp({
         email,
         token,
         type: 'signup',
@@ -77,8 +87,8 @@ export default function OTPVerification({
             text: 'OK',
             onPress: () => {
               onVerificationSuccess?.();
-            }
-          }
+            },
+          },
         ]);
       } else {
         setErrorMessage('Verification failed. Please try again.');
@@ -86,7 +96,7 @@ export default function OTPVerification({
     } catch (error) {
       setErrorMessage('An error occurred during verification.');
     }
-    
+
     setLoading(false);
   };
 
@@ -118,32 +128,27 @@ export default function OTPVerification({
   return (
     <ViewContainer style={styles.container}>
       <ViewHeader style={styles.header}>Verify Email</ViewHeader>
-      
+
       <ViewSection style={{ marginTop: 30 }}>
-        <Text style={styles.subtitle}>
-          We've sent a verification code to
-        </Text>
+        <Text style={styles.subtitle}>We've sent a verification code to</Text>
         <Text style={styles.emailText}>{email}</Text>
-        
+
         {/* Hidden input for handling paste and continuous typing */}
         <TextInput
           ref={hiddenInputRef}
           value={fullOtp}
           onChangeText={handleFullOtpChange}
           style={styles.hiddenInput}
-          keyboardType="number-pad"
+          keyboardType='number-pad'
           maxLength={6}
           autoFocus={true}
         />
-        
+
         <View style={styles.otpContainer}>
           {otp.map((digit, index) => (
             <TouchableOpacity
               key={index}
-              style={[
-                styles.otpBox,
-                digit && styles.otpBoxFilled
-              ]}
+              style={[styles.otpBox, digit && styles.otpBoxFilled]}
               onPress={handleBoxPress}
               activeOpacity={0.7}
             >
@@ -168,21 +173,15 @@ export default function OTPVerification({
 
         <View style={styles.resendContainer}>
           <Text style={styles.resendText}>Didn't receive the code? </Text>
-          <TouchableOpacity 
-            onPress={handleResendOTP}
-            disabled={resendLoading}
-          >
+          <TouchableOpacity onPress={handleResendOTP} disabled={resendLoading}>
             <Text style={styles.resendLink}>
               {resendLoading ? 'Sending...' : 'Resend'}
             </Text>
           </TouchableOpacity>
         </View>
 
-        <TouchableOpacity 
-          style={styles.backButton}
-          onPress={onBackToSignUp}
-        >
-          <MaterialIcons name="arrow-back" size={20} color="#666" />
+        <TouchableOpacity style={styles.backButton} onPress={onBackToSignUp}>
+          <MaterialIcons name='arrow-back' size={20} color='#666' />
           <Text style={styles.backButtonText}>Back to Sign Up</Text>
         </TouchableOpacity>
       </ViewSection>

--- a/unify-front-end/components/AuthComponents/OTPConfirmation.tsx
+++ b/unify-front-end/components/AuthComponents/OTPConfirmation.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet, Alert } from 'react-native';
 import { supabase } from '../../lib/supabase';
 import { MaterialIcons } from '@expo/vector-icons';
@@ -27,20 +27,26 @@ export default function OTPVerification({
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [resendLoading, setResendLoading] = useState(false);
+  const [fullOtp, setFullOtp] = useState('');
+  const hiddenInputRef = useRef<TextInput>(null);
 
-  const handleChange = (index: number, value: string) => {
-    if (/^\d$/.test(value) || value === '') {
-      const newOtp = [...otp];
-      newOtp[index] = value;
-      setOtp(newOtp);
-      
-      // Auto-focus next input
-      if (value && index < 5) {
-        // This would require refs to implement auto-focus
-      }
+  const handleFullOtpChange = (text: string) => {
+    const digitsOnly = text.replace(/[^0-9]/g, '');
+  
+    const truncated = digitsOnly.slice(0, 6);
+    setFullOtp(truncated);
+
+    const newOtp = [...otp];
+    for (let i = 0; i < 6; i++) {
+      newOtp[i] = truncated[i] || '';
     }
+    setOtp(newOtp);
   };
-  // handle the otp length
+
+  const handleBoxPress = () => {
+    hiddenInputRef.current?.focus();
+  };
+
   const handleVerify = async () => {
     const token = otp.join('');
     if (token.length !== 6) {
@@ -51,7 +57,7 @@ export default function OTPVerification({
     setLoading(true);
     setErrorMessage(null);
 
-    try {      
+    try {
       const { data: { session }, error: verifyError } = await supabase.auth.verifyOtp({
         email,
         token,
@@ -98,6 +104,9 @@ export default function OTPVerification({
         setErrorMessage(error.message);
       } else {
         Alert.alert('Success', 'OTP resent successfully!');
+        // clear the otp input after resending
+        setOtp(['', '', '', '', '', '']);
+        setFullOtp('');
       }
     } catch (error) {
       setErrorMessage('Failed to resend OTP.');
@@ -116,20 +125,30 @@ export default function OTPVerification({
         </Text>
         <Text style={styles.emailText}>{email}</Text>
         
+        {/* Hidden input for handling paste and continuous typing */}
+        <TextInput
+          ref={hiddenInputRef}
+          value={fullOtp}
+          onChangeText={handleFullOtpChange}
+          style={styles.hiddenInput}
+          keyboardType="number-pad"
+          maxLength={6}
+          autoFocus={true}
+        />
+        
         <View style={styles.otpContainer}>
           {otp.map((digit, index) => (
-            <TextInput
+            <TouchableOpacity
               key={index}
-              value={digit}
-              onChangeText={(val) => handleChange(index, val)}
-              keyboardType="number-pad"
-              maxLength={1}
               style={[
-                styles.otpInput,
-                digit && styles.otpInputFilled
+                styles.otpBox,
+                digit && styles.otpBoxFilled
               ]}
-              textAlign="center"
-            />
+              onPress={handleBoxPress}
+              activeOpacity={0.7}
+            >
+              <Text style={styles.otpDigit}>{digit}</Text>
+            </TouchableOpacity>
           ))}
         </View>
 
@@ -199,25 +218,36 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: 32 * 0.87,
   },
+  hiddenInput: {
+    position: 'absolute',
+    opacity: 0,
+    height: 0,
+    width: 0,
+  },
   otpContainer: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     marginBottom: 32 * 0.87,
     paddingHorizontal: 20 * 0.87,
   },
-  otpInput: {
+  otpBox: {
     width: 45 * 0.87,
     height: 55 * 0.87,
     borderWidth: 1 * 0.87,
     borderColor: '#ccc',
     borderRadius: 8 * 0.87,
-    fontSize: 20 * 0.87,
-    fontWeight: '600' as '600',
     backgroundColor: '#fff',
+    justifyContent: 'center' as 'center',
+    alignItems: 'center' as 'center',
   },
-  otpInputFilled: {
+  otpBoxFilled: {
     borderColor: '#343434',
     backgroundColor: '#f8f8f8',
+  },
+  otpDigit: {
+    fontSize: 20 * 0.87,
+    fontWeight: '600' as '600',
+    color: '#000',
   },
   errorMessage: {
     color: '#f00',

--- a/unify-front-end/components/AuthComponents/OTPConfirmation.tsx
+++ b/unify-front-end/components/AuthComponents/OTPConfirmation.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, Alert } from 'react-native';
+import { supabase } from '@/lib/supabase'; // adjust path based on your project
+
+export default function OTPVerification({ email }: { email: string }) {
+  const [otp, setOtp] = useState(['', '', '', '', '', '']);
+
+  const handleChange = (index: number, value: string) => {
+    if (/^\d$/.test(value) || value === '') {
+      const newOtp = [...otp];
+      newOtp[index] = value;
+      setOtp(newOtp);
+    }
+  };
+
+  const handleVerify = async () => {
+    const token = otp.join('');
+    const { data: { session }, error } = await supabase.auth.verifyOtp({
+      email,
+      token,
+      type: 'email',
+    });
+
+    if (error) {
+      Alert.alert('Verification failed', error.message);
+    } else {
+      Alert.alert('Success', 'Logged in!');
+      // TODO: Navigate to home screen or store session
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Forgot Password</Text>
+      <Text style={styles.subtitle}>Enter OTP</Text>
+      <View style={styles.otpContainer}>
+        {otp.map((digit, index) => (
+          <TextInput
+            key={index}
+            value={digit}
+            onChangeText={(val) => handleChange(index, val)}
+            keyboardType="number-pad"
+            maxLength={1}
+            style={styles.otpInput}
+          />
+        ))}
+      </View>
+
+      <TouchableOpacity onPress={handleVerify} style={styles.verifyButton}>
+        <Text style={styles.verifyText}>Verify</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity>
+        <Text style={styles.resend}>Send Again</Text>
+      </TouchableOpacity>
+
+      <TouchableOpacity>
+        <Text style={styles.cancel}>Cancel</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    paddingTop: 100,
+    paddingHorizontal: 24,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#d63677',
+    marginBottom: 16,
+  },
+  subtitle: {
+    fontSize: 18,
+    fontWeight: '500',
+    marginBottom: 24,
+  },
+  otpContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 10,
+    marginBottom: 32,
+  },
+  otpInput: {
+    borderBottomWidth: 2,
+    borderColor: '#ccc',
+    width: 40,
+    fontSize: 20,
+    textAlign: 'center',
+  },
+  verifyButton: {
+    backgroundColor: '#ff3370',
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    borderRadius: 25,
+    marginBottom: 16,
+  },
+  verifyText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  resend: {
+    color: '#ff3370',
+    textDecorationLine: 'underline',
+    marginBottom: 12,
+  },
+  cancel: {
+    color: '#888',
+  },
+});

--- a/unify-front-end/components/AuthComponents/OTPConfirmation.tsx
+++ b/unify-front-end/components/AuthComponents/OTPConfirmation.tsx
@@ -1,115 +1,271 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, TouchableOpacity, StyleSheet, Alert } from 'react-native';
-import { supabase } from '@/lib/supabase'; // adjust path based on your project
+import { supabase } from '../../lib/supabase';
+import { MaterialIcons } from '@expo/vector-icons';
+import {
+  ViewHeader,
+  ViewContainer,
+  ViewSection,
+  SubmitButton,
+  SimpleTextField,
+} from './Components';
 
-export default function OTPVerification({ email }: { email: string }) {
+interface OTPVerificationProps {
+  email: string;
+  password: string;
+  onVerificationSuccess?: () => void;
+  onBackToSignUp?: () => void;
+}
+
+export default function OTPVerification({ 
+  email, 
+  password, 
+  onVerificationSuccess,
+  onBackToSignUp 
+}: OTPVerificationProps) {
   const [otp, setOtp] = useState(['', '', '', '', '', '']);
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [resendLoading, setResendLoading] = useState(false);
 
   const handleChange = (index: number, value: string) => {
     if (/^\d$/.test(value) || value === '') {
       const newOtp = [...otp];
       newOtp[index] = value;
       setOtp(newOtp);
+      
+      // Auto-focus next input
+      if (value && index < 5) {
+        // This would require refs to implement auto-focus
+      }
     }
   };
-
+  // handle the otp length
   const handleVerify = async () => {
     const token = otp.join('');
-    const { data: { session }, error } = await supabase.auth.verifyOtp({
-      email,
-      token,
-      type: 'email',
-    });
-
-    if (error) {
-      Alert.alert('Verification failed', error.message);
-    } else {
-      Alert.alert('Success', 'Logged in!');
-      // TODO: Navigate to home screen or store session
+    if (token.length !== 6) {
+      setErrorMessage('Please enter the complete 6-digit code');
+      return;
     }
+
+    setLoading(true);
+    setErrorMessage(null);
+
+    try {      
+      const { data: { session }, error: verifyError } = await supabase.auth.verifyOtp({
+        email,
+        token,
+        type: 'signup',
+      });
+
+      if (verifyError) {
+        setErrorMessage(verifyError.message);
+        setLoading(false);
+        return;
+      }
+
+      if (session) {
+        // NOTE: just alert for now, until we have a UI designed for thos
+        Alert.alert('Success', 'Email verified successfully!', [
+          {
+            text: 'OK',
+            onPress: () => {
+              onVerificationSuccess?.();
+            }
+          }
+        ]);
+      } else {
+        setErrorMessage('Verification failed. Please try again.');
+      }
+    } catch (error) {
+      setErrorMessage('An error occurred during verification.');
+    }
+    
+    setLoading(false);
+  };
+
+  const handleResendOTP = async () => {
+    setResendLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const { error } = await supabase.auth.signUp({
+        email,
+        password,
+      });
+
+      if (error) {
+        setErrorMessage(error.message);
+      } else {
+        Alert.alert('Success', 'OTP resent successfully!');
+      }
+    } catch (error) {
+      setErrorMessage('Failed to resend OTP.');
+    }
+
+    setResendLoading(false);
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Forgot Password</Text>
-      <Text style={styles.subtitle}>Enter OTP</Text>
-      <View style={styles.otpContainer}>
-        {otp.map((digit, index) => (
-          <TextInput
-            key={index}
-            value={digit}
-            onChangeText={(val) => handleChange(index, val)}
-            keyboardType="number-pad"
-            maxLength={1}
-            style={styles.otpInput}
-          />
-        ))}
-      </View>
+    <ViewContainer style={styles.container}>
+      <ViewHeader style={styles.header}>Verify Email</ViewHeader>
+      
+      <ViewSection style={{ marginTop: 30 }}>
+        <Text style={styles.subtitle}>
+          We've sent a verification code to
+        </Text>
+        <Text style={styles.emailText}>{email}</Text>
+        
+        <View style={styles.otpContainer}>
+          {otp.map((digit, index) => (
+            <TextInput
+              key={index}
+              value={digit}
+              onChangeText={(val) => handleChange(index, val)}
+              keyboardType="number-pad"
+              maxLength={1}
+              style={[
+                styles.otpInput,
+                digit && styles.otpInputFilled
+              ]}
+              textAlign="center"
+            />
+          ))}
+        </View>
 
-      <TouchableOpacity onPress={handleVerify} style={styles.verifyButton}>
-        <Text style={styles.verifyText}>Verify</Text>
-      </TouchableOpacity>
+        {errorMessage && (
+          <Text style={styles.errorMessage}>{errorMessage}</Text>
+        )}
 
-      <TouchableOpacity>
-        <Text style={styles.resend}>Send Again</Text>
-      </TouchableOpacity>
+        <SubmitButton
+          disabled={otp.join('').length !== 6}
+          loading={loading}
+          onPress={handleVerify}
+          style={[styles.verifyButton]}
+          labelStyle={[styles.verifyButtonText]}
+        >
+          Verify Email
+        </SubmitButton>
 
-      <TouchableOpacity>
-        <Text style={styles.cancel}>Cancel</Text>
-      </TouchableOpacity>
-    </View>
+        <View style={styles.resendContainer}>
+          <Text style={styles.resendText}>Didn't receive the code? </Text>
+          <TouchableOpacity 
+            onPress={handleResendOTP}
+            disabled={resendLoading}
+          >
+            <Text style={styles.resendLink}>
+              {resendLoading ? 'Sending...' : 'Resend'}
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <TouchableOpacity 
+          style={styles.backButton}
+          onPress={onBackToSignUp}
+        >
+          <MaterialIcons name="arrow-back" size={20} color="#666" />
+          <Text style={styles.backButtonText}>Back to Sign Up</Text>
+        </TouchableOpacity>
+      </ViewSection>
+    </ViewContainer>
   );
 }
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
-    alignItems: 'center',
-    paddingTop: 100,
-    paddingHorizontal: 24,
+    padding: 16 * 0.87,
+    paddingLeft: 24 * 0.87,
+    paddingRight: 24 * 0.87,
   },
-  title: {
-    fontSize: 24,
-    fontWeight: '700',
-    color: '#d63677',
-    marginBottom: 16,
+  header: {
+    fontSize: 34 * 0.87,
+    fontWeight: '700' as '700',
+    color: '#000',
+    marginBottom: 7 * 0.87,
+    marginTop: 110 * 0.87,
   },
   subtitle: {
-    fontSize: 18,
-    fontWeight: '500',
-    marginBottom: 24,
+    fontSize: 16 * 0.87,
+    color: '#666',
+    textAlign: 'center',
+    marginBottom: 8 * 0.87,
+  },
+  emailText: {
+    fontSize: 16 * 0.87,
+    fontWeight: '600' as '600',
+    color: '#000',
+    textAlign: 'center',
+    marginBottom: 32 * 0.87,
   },
   otpContainer: {
     flexDirection: 'row',
-    justifyContent: 'center',
-    gap: 10,
-    marginBottom: 32,
+    justifyContent: 'space-between',
+    marginBottom: 32 * 0.87,
+    paddingHorizontal: 20 * 0.87,
   },
   otpInput: {
-    borderBottomWidth: 2,
+    width: 45 * 0.87,
+    height: 55 * 0.87,
+    borderWidth: 1 * 0.87,
     borderColor: '#ccc',
-    width: 40,
-    fontSize: 20,
+    borderRadius: 8 * 0.87,
+    fontSize: 20 * 0.87,
+    fontWeight: '600' as '600',
+    backgroundColor: '#fff',
+  },
+  otpInputFilled: {
+    borderColor: '#343434',
+    backgroundColor: '#f8f8f8',
+  },
+  errorMessage: {
+    color: '#f00',
+    fontSize: 14 * 0.87,
     textAlign: 'center',
+    marginBottom: 16 * 0.87,
   },
   verifyButton: {
-    backgroundColor: '#ff3370',
-    paddingVertical: 12,
-    paddingHorizontal: 32,
-    borderRadius: 25,
-    marginBottom: 16,
+    backgroundColor: '#343434',
+    borderRadius: 40 * 0.87,
+    marginTop: 16 * 0.87,
+    width: 200 * 0.87,
+    height: 42 * 0.87,
+    alignSelf: 'center' as 'center',
+    justifyContent: 'center' as 'center',
+    alignItems: 'center' as 'center',
   },
-  verifyText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
+  verifyButtonText: {
+    color: 'white',
+    textAlign: 'center' as 'center',
+    fontSize: 16 * 0.87,
+    fontWeight: '600' as '600',
   },
-  resend: {
-    color: '#ff3370',
-    textDecorationLine: 'underline',
-    marginBottom: 12,
+  resendContainer: {
+    flexDirection: 'row' as 'row',
+    justifyContent: 'center' as 'center',
+    alignItems: 'center' as 'center',
+    marginTop: 24 * 0.87,
   },
-  cancel: {
-    color: '#888',
+  resendText: {
+    fontSize: 14 * 0.87,
+    color: '#666',
+  },
+  resendLink: {
+    fontSize: 14 * 0.87,
+    color: '#343434',
+    fontWeight: '600' as '600',
+    textDecorationLine: 'underline' as 'underline',
+  },
+  backButton: {
+    flexDirection: 'row' as 'row',
+    alignItems: 'center' as 'center',
+    justifyContent: 'center' as 'center',
+    marginTop: 32 * 0.87,
+  },
+  backButtonText: {
+    fontSize: 14 * 0.87,
+    color: '#666',
+    marginLeft: 8 * 0.87,
   },
 });

--- a/unify-front-end/components/AuthComponents/SignIn.tsx
+++ b/unify-front-end/components/AuthComponents/SignIn.tsx
@@ -81,7 +81,7 @@ export function SignIn({
             autoCapitalize='none'
           />
           {isEmailValid && (
-            <MaterialIcons name='check-circle' size={24} color='#333' />
+            <MaterialIcons name='check-circle' size={24} color='#333' style={styles.tickIcon}/>
           )}
         </View>
         <View>

--- a/unify-front-end/components/AuthComponents/SignIn.tsx
+++ b/unify-front-end/components/AuthComponents/SignIn.tsx
@@ -81,7 +81,12 @@ export function SignIn({
             autoCapitalize='none'
           />
           {isEmailValid && (
-            <MaterialIcons name='check-circle' size={24} color='#333' style={styles.tickIcon}/>
+            <MaterialIcons
+              name='check-circle'
+              size={24}
+              color='#333'
+              style={styles.tickIcon}
+            />
           )}
         </View>
         <View>

--- a/unify-front-end/components/AuthComponents/SignUp.tsx
+++ b/unify-front-end/components/AuthComponents/SignUp.tsx
@@ -78,30 +78,22 @@ export function SignUp({
     setLoading(true);
     setErrorMessage(null);
 
-    try {
-      console.log('Starting signup process for:', email);
-      
-      // Send OTP to user's email
+    try {      
+      // send theOTP to user's email
       const { data, error } = await supabase.auth.signUp({
         email: email,
         password: password,
       });
 
-      console.log('Signup response:', { data, error });
-
       if (error) {
-        console.error('Signup error:', error);
         setErrorMessage(error.message);
         setLoading(false);
         return;
       }
 
-      console.log('Signup successful, showing OTP screen');
-      
       // If successful, show OTP verification screen
       onShowOTP?.(email, password);
     } catch (error) {
-      console.error('Unexpected error during signup:', error);
       setErrorMessage('An error occurred during sign up.');
     }
     

--- a/unify-front-end/components/AuthComponents/SignUp.tsx
+++ b/unify-front-end/components/AuthComponents/SignUp.tsx
@@ -21,7 +21,7 @@ import {
   ViewSection,
   ViewDivider,
 } from './Components';
-
+import { useNavigation } from '@react-navigation/native'; // Adjust the import based on your project structure
 function capitalize<T extends string>([first, ...rest]: T): Capitalize<T> {
   return [first && first.toUpperCase(), rest.join('').toLowerCase()]
     .filter(Boolean)
@@ -49,6 +49,8 @@ export function SignUp({
   const [loading, setLoading] = React.useState(false);
   const [isChecked, setIsChecked] = React.useState(false);
 
+  const navigation = useNavigation();
+
   const validateEmail = (email: string) => {
     // Simple email validation regex
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -74,6 +76,7 @@ export function SignUp({
     // if (!session) Alert.alert('Please check your inbox for email verification!')
     if (error) setErrorMessage(error.message);
     setLoading(false);
+    navigation.navigate({ name: 'OTPVerification', params: { email } });
   };
   return (
     <ViewContainer style={styles.container}>

--- a/unify-front-end/components/AuthComponents/SignUp.tsx
+++ b/unify-front-end/components/AuthComponents/SignUp.tsx
@@ -30,8 +30,10 @@ function capitalize<T extends string>([first, ...rest]: T): Capitalize<T> {
 
 export function SignUp({
   onSwitchToSignIn,
+  onShowOTP,
 }: {
   onSwitchToSignIn?: () => void;
+  onShowOTP?: (email: string, password: string) => void;
 }): React.JSX.Element {
   const {
     formState: { errors, isValid },
@@ -62,21 +64,48 @@ export function SignUp({
       setErrorMessage('Passwords do not match');
       return;
     }
+    
+    if (!isEmailValid) {
+      setErrorMessage('Please enter a valid email address');
+      return;
+    }
+
+    if (!isChecked) {
+      setErrorMessage('Please accept the terms and privacy policy');
+      return;
+    }
+
     setLoading(true);
     setErrorMessage(null);
-    const {
-      data: { session },
-      error,
-    } = await supabase.auth.signUp({
-      email: email,
-      password: password,
-    });
 
-    // if (error) Alert.alert(error.message)
-    // if (!session) Alert.alert('Please check your inbox for email verification!')
-    if (error) setErrorMessage(error.message);
+    try {
+      console.log('Starting signup process for:', email);
+      
+      // Send OTP to user's email
+      const { data, error } = await supabase.auth.signUp({
+        email: email,
+        password: password,
+      });
+
+      console.log('Signup response:', { data, error });
+
+      if (error) {
+        console.error('Signup error:', error);
+        setErrorMessage(error.message);
+        setLoading(false);
+        return;
+      }
+
+      console.log('Signup successful, showing OTP screen');
+      
+      // If successful, show OTP verification screen
+      onShowOTP?.(email, password);
+    } catch (error) {
+      console.error('Unexpected error during signup:', error);
+      setErrorMessage('An error occurred during sign up.');
+    }
+    
     setLoading(false);
-    navigation.navigate({ name: 'OTPVerification', params: { email } });
   };
   return (
     <ViewContainer style={styles.container}>
@@ -181,12 +210,12 @@ export function SignUp({
       </View>
 
       <SubmitButton
-        disabled={!isValid || !isChecked}
+        disabled={!isEmailValid || !password || !confirmPassword || !isChecked}
         loading={loading}
         onPress={handleSignUp}
         style={[
           styles.button,
-          (!isValid || !isChecked) && styles.buttonDisabled, // Button is disabled is privacy poli checkbox not checked
+          (!isEmailValid || !password || !confirmPassword || !isChecked) && styles.buttonDisabled,
         ]}
         labelStyle={[styles.buttonText]}
       >

--- a/unify-front-end/components/AuthComponents/SignUp.tsx
+++ b/unify-front-end/components/AuthComponents/SignUp.tsx
@@ -111,7 +111,7 @@ export function SignUp({
               setEmail(text);
               validateEmail(text);
             }}
-            placeholder='email@address.com'
+            placeholder='Your email'
             style={[styles.textField, errorMessage && { borderColor: '#f00' }]}
             autoCapitalize='none'
           />
@@ -131,7 +131,7 @@ export function SignUp({
           <SimpleTextField
             value={password}
             onChangeText={setPassword}
-            placeholder='Password'
+            placeholder='Your password'
             style={[styles.textField, errorMessage && { borderColor: '#f00' }]}
             secureTextEntry={!passwordVisible}
             autoCapitalize='none'

--- a/unify-front-end/components/AuthComponents/SignUp.tsx
+++ b/unify-front-end/components/AuthComponents/SignUp.tsx
@@ -64,7 +64,7 @@ export function SignUp({
       setErrorMessage('Passwords do not match');
       return;
     }
-    
+
     if (!isEmailValid) {
       setErrorMessage('Please enter a valid email address');
       return;
@@ -78,7 +78,7 @@ export function SignUp({
     setLoading(true);
     setErrorMessage(null);
 
-    try {      
+    try {
       // send theOTP to user's email
       const { data, error } = await supabase.auth.signUp({
         email: email,
@@ -96,7 +96,7 @@ export function SignUp({
     } catch (error) {
       setErrorMessage('An error occurred during sign up.');
     }
-    
+
     setLoading(false);
   };
   return (
@@ -207,7 +207,8 @@ export function SignUp({
         onPress={handleSignUp}
         style={[
           styles.button,
-          (!isEmailValid || !password || !confirmPassword || !isChecked) && styles.buttonDisabled,
+          (!isEmailValid || !password || !confirmPassword || !isChecked) &&
+            styles.buttonDisabled,
         ]}
         labelStyle={[styles.buttonText]}
       >


### PR DESCRIPTION
## Title
- OTP and 3rd party sign up. 

## What was done

- Added the OTPConfirmation component (feature the OTP verifying page)
- Reconfigure the Sign Up auth, user are now only authenticated once they verify their email with OTP
- Redesign the sign up email with supabase 
- Have the supabase email to be sent from Unify's email (blocked)
- 3rd party sign up with Google, Apple, Facebook (blocked)

## Frontend Screenshots (if applicable)
NOTE: The design here is just for now, waiting for the official design from the design team. This is just what I came up with based on the theme we had with the sign in and sign up pages.
<img width="651" height="948" alt="image" src="https://github.com/user-attachments/assets/e73fde68-4714-41f0-a227-df6c81915861" />

## Check list
- Run 'npm run format' to prettier your changes
- Code builds without errors
- No console errors
