### PR TITLE
Add chatbot rate limiting that resets per day

### DIFF
--- a/unify-back-end/src/database/schema.sql
+++ b/unify-back-end/src/database/schema.sql
@@ -73,6 +73,14 @@ CREATE TABLE group_members (
     PRIMARY KEY (user_id, group_id)
 );
 
+-- Chatbot usage table, to track how many messages in the past day and rate limit (will only be upserting)
+CREATE TABLE chatbot_usage (
+    user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    -- might need to add 'premium BOOLEAN' in the future to account for multiple limits but for now assume all have a limit
+    message_count INTEGER DEFAULT 0,
+    last_message_at TIMESTAMP DEFAULT NOW() -- Will be UTC times, so usage resets based on UTC midnight
+);
+
 -- Main Topics table
 CREATE TABLE main_topics (
     id SERIAL PRIMARY KEY,

--- a/unify-front-end/components/ChatBot/ChatBotModal.tsx
+++ b/unify-front-end/components/ChatBot/ChatBotModal.tsx
@@ -12,6 +12,8 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { isGeminiAvailable, callGeminiAPI } from '@/utils/gemini';
+import { useChatbotUsage } from '@/hooks/chatbot/useChatbotUsage';
+import { useUpdateChatbotUsage } from '@/hooks/chatbot/useUpdateChatbotUsage';
 
 interface Message {
   id: string;
@@ -31,6 +33,13 @@ export const ChatBotModal = ({ visible, onClose }: ChatBotModalProps) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isApiAvailable, setIsApiAvailable] = useState(true);
   const flatListRef = useRef<FlatList>(null);
+
+  const { data: usage, isLoading: isLoadingUsage } = useChatbotUsage();
+  const updateUsage = useUpdateChatbotUsage();
+
+  const MESSAGE_LIMIT = 3; // Daily message limit, applicable to everyone but could be changed/ignored for premium members in the future
+  const messagesLeft = MESSAGE_LIMIT - usage?.message_count!;
+  const canSendMessage = messagesLeft > 0;
 
   // Check API availability and initialize with appropriate message
   useEffect(() => {
@@ -62,7 +71,8 @@ export const ChatBotModal = ({ visible, onClose }: ChatBotModalProps) => {
   }, [visible]);
 
   const sendMessage = async () => {
-    if (!inputText.trim() || isLoading || !isApiAvailable) return;
+    if (!inputText.trim() || isLoading || !isApiAvailable || !canSendMessage)
+      return;
 
     const userMessage: Message = {
       id: Date.now().toString(),
@@ -78,6 +88,9 @@ export const ChatBotModal = ({ visible, onClose }: ChatBotModalProps) => {
     try {
       // Call the Gemini API through Supabase edge function
       const response = await callGeminiAPI(userMessage.text);
+
+      const newMessageCount = (usage?.message_count ?? 0) + 1;
+      updateUsage.mutate(newMessageCount);
 
       // Extract the response text from the Gemini API response
       let botResponse = 'Sorry, I encountered an error. Please try again.';
@@ -195,34 +208,66 @@ export const ChatBotModal = ({ visible, onClose }: ChatBotModalProps) => {
           ListFooterComponent={renderLoadingIndicator}
         />
 
+        {/* Message Count Display */}
+        <View style={styles.messageCountContainer}>
+          <Text
+            style={[
+              styles.messageCountText,
+              messagesLeft <= 0 && styles.messageCountTextWarning,
+            ]}
+          >
+            {isLoadingUsage
+              ? 'Loading...'
+              : `${messagesLeft}/${MESSAGE_LIMIT} messages left today`}
+          </Text>
+        </View>
+
         {/* Input */}
         <View style={styles.inputContainer}>
           <TextInput
-            style={[styles.textInput, !isApiAvailable && styles.disabledInput]}
+            style={[
+              styles.textInput,
+              (!isApiAvailable || !canSendMessage) && styles.disabledInput,
+            ]}
             value={inputText}
             onChangeText={setInputText}
             placeholder={
-              isApiAvailable ? 'Type your message...' : 'Chat unavailable'
+              !isApiAvailable
+                ? 'Chat unavailable'
+                : !canSendMessage
+                  ? 'Daily limit reached'
+                  : 'Type your message...'
             }
             placeholderTextColor='#999'
             multiline
             maxLength={500}
-            editable={!isLoading && isApiAvailable}
+            editable={!isLoading && isApiAvailable && canSendMessage}
           />
           <TouchableOpacity
             style={[
               styles.sendButton,
-              (!inputText.trim() || isLoading || !isApiAvailable) &&
+              (!inputText.trim() ||
+                isLoading ||
+                !isApiAvailable ||
+                !canSendMessage) &&
                 styles.sendButtonDisabled,
             ]}
             onPress={sendMessage}
-            disabled={!inputText.trim() || isLoading || !isApiAvailable}
+            disabled={
+              !inputText.trim() ||
+              isLoading ||
+              !isApiAvailable ||
+              !canSendMessage
+            }
           >
             <Ionicons
               name='send'
               size={20}
               color={
-                !inputText.trim() || isLoading || !isApiAvailable
+                !inputText.trim() ||
+                isLoading ||
+                !isApiAvailable ||
+                !canSendMessage
                   ? '#ccc'
                   : '#fff'
               }
@@ -329,10 +374,8 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'flex-end',
     paddingHorizontal: 15,
-    paddingVertical: 40,
+    paddingBottom: 40,
     backgroundColor: '#fff',
-    borderTopWidth: 1,
-    borderTopColor: '#e0e0e0',
   },
   textInput: {
     flex: 1,
@@ -361,5 +404,25 @@ const styles = StyleSheet.create({
   },
   sendButtonDisabled: {
     backgroundColor: '#e0e0e0',
+  },
+  messageCountContainer: {
+    paddingHorizontal: 15,
+    paddingVertical: 10,
+    backgroundColor: '#fff',
+    borderTopWidth: 1,
+    borderTopColor: '#e0e0e0',
+  },
+  messageCountText: {
+    fontSize: 14,
+    color: '#666',
+    textAlign: 'center',
+  },
+  messageCountTextWarning: {
+    color: '#ff6b6b',
+    fontWeight: '600',
+  },
+  inputWrapper: {
+    flex: 1,
+    position: 'relative',
   },
 });

--- a/unify-front-end/hooks/chatbot/useChatbotUsage.ts
+++ b/unify-front-end/hooks/chatbot/useChatbotUsage.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getChatbotUsage } from '../../services/chatbot/getChatbotUsage';
+import { ChatbotUsage } from '../../types/chatbot';
+
+export const useChatbotUsage = () => {
+  return useQuery<ChatbotUsage>({
+    queryKey: ['chatbot-usage'],
+    queryFn: () => getChatbotUsage(),
+  });
+};

--- a/unify-front-end/hooks/chatbot/useUpdateChatbotUsage.ts
+++ b/unify-front-end/hooks/chatbot/useUpdateChatbotUsage.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { upsertChatbotUsage } from '../../services/chatbot/upsertChatbotUsage';
+
+export const useUpdateChatbotUsage = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (new_message_count: number) =>
+      upsertChatbotUsage({ new_message_count }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['chatbot-usage'],
+      });
+    },
+  });
+};

--- a/unify-front-end/services/chatbot/getChatbotUsage.ts
+++ b/unify-front-end/services/chatbot/getChatbotUsage.ts
@@ -1,0 +1,52 @@
+import { supabase } from '../../lib/supabase';
+import { ChatbotUsage } from '../../types/chatbot';
+
+export const getChatbotUsage = async (): Promise<ChatbotUsage> => {
+  try {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new Error('No authenticated user');
+
+    const { data } = await supabase
+      .from('chatbot_usage')
+      .select('user_id, message_count, last_message_at')
+      .eq('user_id', user.id)
+      .single();
+
+    // If no record exists, return default values
+    if (!data) {
+      return {
+        message_count: 0,
+        last_message_at: null,
+      };
+    }
+
+    // Check if it's a new day and reset count if needed
+    const now = new Date();
+    const currentDate = now.toISOString().split('T')[0]; // YYYY-MM-DD format
+
+    if (data.last_message_at) {
+      const lastMessageDate = data.last_message_at.split('T')[0];
+
+      if (lastMessageDate !== currentDate) {
+        // New day - reset count to 0
+        return {
+          message_count: 0,
+          last_message_at: data.last_message_at,
+        };
+      }
+    }
+
+    // Same day or no previous message - return actual count
+    return {
+      message_count: data.message_count ?? 0,
+      last_message_at: data.last_message_at ?? null,
+    };
+  } catch (error) {
+    return {
+      message_count: 0,
+      last_message_at: null,
+    };
+  }
+};

--- a/unify-front-end/services/chatbot/upsertChatbotUsage.ts
+++ b/unify-front-end/services/chatbot/upsertChatbotUsage.ts
@@ -1,0 +1,35 @@
+import { supabase } from '../../lib/supabase';
+import { UpsertChatbotUsageParams } from '../../types/chatbot';
+
+export const upsertChatbotUsage = async (
+  params: UpsertChatbotUsageParams
+): Promise<boolean> => {
+  try {
+    const { new_message_count } = params;
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new Error('No authenticated user');
+
+    const { error } = await supabase.from('chatbot_usage').upsert(
+      {
+        user_id: user.id,
+        message_count: new_message_count,
+        last_message_at: new Date().toISOString(),
+      },
+      {
+        onConflict: 'user_id',
+      }
+    );
+
+    if (error) {
+      console.error('Error upserting chatbot usage:', error);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error('Error in upsertChatbotUsage:', error);
+    return false;
+  }
+};

--- a/unify-front-end/types/chatbot.ts
+++ b/unify-front-end/types/chatbot.ts
@@ -1,0 +1,4 @@
+export interface ChatbotUsage {
+  message_count: number;
+  last_message_at: string | null;
+}


### PR DESCRIPTION
## Title
- Implement usage limit for the chatbot that resets on UTC Midnight, so we dont have to hassle with timezones

## Link
[Link](https://app.clickup.com/t/86aaj0ggg)

## What was done
[Describe the changes made]
- Add table to track user_id, message_count, last_message_at
- Add two hooks to update message_count and get how many messages user has sent on the current UTC day
- The limit will reset after UTC midnight so not 24 hours just whenever a new UTC date which is fine IMO

## Frontend Screenshots (if applicable)
[Add screenshots or videos of UI changes]
- Video of user reaching daily limit and cant send any more: [here](https://streamable.com/hjpf6h)
- Video of resetting/setting last_message_at to be a day behind to show that it resets: [here](https://streamable.com/hulvdf)

## Please make sure you did these
- Run 'npm run format' to prettier your changes (seriously please run it - bq)
- Code builds without errors
- No console errors

## Reminder
Please assign yourself this PR in the sidebar