### PR TITLE
Learn page refactoring

### DIFF
--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/index.tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/index.tsx
@@ -1,48 +1,57 @@
-import React, { useMemo, useRef, useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, SafeAreaView, ScrollView, Dimensions, LayoutChangeEvent } from 'react-native';
+import React, { useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  SafeAreaView,
+  ScrollView,
+  Dimensions,
+  LayoutChangeEvent,
+} from 'react-native';
 import { useRouter, useLocalSearchParams, Link } from 'expo-router';
 import { useModule } from '@/hooks/learn/useModule';
 import { Feather } from '@expo/vector-icons';
-import Svg, { Path } from 'react-native-svg';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+
+/** layout constants */
+const EDGE_PAD = 16;
+const CONTENT_W = SCREEN_WIDTH - EDGE_PAD * 2;
+const CARD_RATIO = 0.75; // 75% width cards
+const CARD_W = Math.min(420, Math.floor(CONTENT_W * CARD_RATIO));
+const RAIL_W = 4;        // unified thickness
+const RAIL_OFFSET = 30;  // distance from rail to bubble
 
 export default function ModuleIndex() {
   const router = useRouter();
   const { moduleId } = useLocalSearchParams<{ moduleId: string }>();
-  
   const { data: moduleData, isLoading, error } = useModule(moduleId || '');
 
-  // Layout and anchors for the connecting path
-  const [containerWidth, setContainerWidth] = useState<number>(0);
-  const [containerHeight, setContainerHeight] = useState<number>(0);
-  const anchorsRef = useRef<number[]>([]);
-  const rowTopsRef = useRef<number[]>([]);
-  const cardBoxesRef = useRef<Array<{ relY: number; height: number } | undefined>>([]);
-  const [layoutTick, setLayoutTick] = useState(0);
+  // rail start/end calculations
+  const [progressBottom, setProgressBottom] = useState(0);
+  const [railEnd, setRailEnd] = useState<number | null>(null);
 
-  const onContainerLayout = (e: LayoutChangeEvent) => {
-    const { width, height } = e.nativeEvent.layout;
-    setContainerWidth(width);
-    setContainerHeight(height);
+  const onProgressLayout = (e: LayoutChangeEvent) => {
+    const { y, height } = e.nativeEvent.layout;
+    setProgressBottom(y + height);
   };
 
-  const setRowTopAndAnchor = (index: number, rowTop: number) => {
-    rowTopsRef.current[index] = rowTop;
-    const iconCenterY = rowTop + 20 + ICON_SIZE / 2;
-    anchorsRef.current[index] = iconCenterY;
-    setLayoutTick(t => t + 1);
-  };
+  const updateRowBottom = (bottom: number) =>
+    setRailEnd(prev => (prev == null ? bottom : Math.max(prev, bottom)));
 
-  const setCardBox = (index: number, relY: number, height: number) => {
-    cardBoxesRef.current[index] = { relY, height };
-    setLayoutTick(t => t + 1);
-  };
+  /** IMPORTANT: call hooks BEFORE any early returns */
+  const railHeight = useMemo(() => {
+    if (!railEnd || progressBottom <= 0) return 0;
+    const trim = 18; // stop a bit before the last card
+    return Math.max(0, railEnd - progressBottom - trim);
+  }, [railEnd, progressBottom]);
 
+  // ---------------- early returns (after hooks) ----------------
   if (isLoading) {
     return (
       <SafeAreaView style={styles.safe}>
-        <View style={styles.loadingContainer}>
-          <Text style={styles.loadingText}>Loading module...</Text>
-        </View>
+        <View style={styles.centered}><Text style={styles.muted}>Loading module…</Text></View>
       </SafeAreaView>
     );
   }
@@ -50,404 +59,286 @@ export default function ModuleIndex() {
   if (error || !moduleData) {
     return (
       <SafeAreaView style={styles.safe}>
-        <View style={styles.loadingContainer}>
-          <Text style={styles.errorText}>Error loading module: {error?.message || 'Unknown error'}</Text>
+        <View style={styles.centered}>
+          <Text style={styles.error}>Error loading module: {error?.message || 'Unknown error'}</Text>
           <Link href='/(tabs)/Learn'>Go back to Learn</Link>
         </View>
       </SafeAreaView>
     );
   }
+  // --------------------------------------------------------------
 
-  const displaySubmodules = moduleData.submodules.map((submodule, i) => ({
-    id: submodule.id,
-    title: submodule.title,
-    moduleNumber: i + 1,
-    stages: submodule.total_stages,
-    progress: submodule.progress_percent / 100,
-    status: submodule.is_completed
-      ? 'completed'
-      : submodule.progress_percent > 0
-      ? 'in-progress'
-      : 'not-started',
-  }));
-
-  const completedCount = moduleData.completed_submodules;
-  const totalModules = moduleData.total_submodules;
-
-  // Get module icon based on title
-  const getModuleIcon = (title: string) => {
-    // Just emojis for now, will have actual icons after the hifi design
-    if (title.toLowerCase().includes('banking') || title.toLowerCase().includes('finance')) {
-      return '🏦';
-    } else if (title.toLowerCase().includes('investing')) {
-      return '📈';
-    } else if (title.toLowerCase().includes('housing') || title.toLowerCase().includes('renting')) {
-      return '🏠';
-    } else if (title.toLowerCase().includes('employment') || title.toLowerCase().includes('job')) {
-      return '💼';
-    }
-    return '📚';
-  };
+  // Normalize list + gating (unlock i if i==0 or previous completed)
+  const submodules = moduleData.submodules.map((s, i, arr) => {
+    const status = s.is_completed ? 'completed' : s.progress_percent > 0 ? 'in-progress' : 'not-started';
+    const unlocked = i === 0 || !!arr[i - 1]?.is_completed;
+    return { ...s, index: i + 1, status, unlocked };
+  });
 
   return (
     <SafeAreaView style={styles.safe}>
       <ScrollView contentContainerStyle={styles.container} showsVerticalScrollIndicator={false}>
-        {/* Header */}
+        {/* Header (no "unify" text here) */}
         <View style={styles.headerRow}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-            <Feather name='arrow-left' size={24} color='#000' />
+            <Feather name='arrow-left' size={26} color='#111' />
           </TouchableOpacity>
+          <View style={{ width: 26 }} />
         </View>
 
-        {/* Module Title Section */}
-        <View style={styles.titleSection}>
+        {/* Title + description */}
+        <View style={styles.titleWrap}>
           <Text style={styles.title}>{moduleData.title}</Text>
-          <Text style={styles.description}>{moduleData.description}</Text>
+          {!!moduleData.description && (
+            <Text style={styles.subtitle}>{moduleData.description}</Text>
+          )}
         </View>
 
         {/* Progress Card */}
-        <View style={styles.progressCard}>
-          <Text style={styles.progressText}>
-            Progress: {completedCount}/{totalModules} modules completed
+        <View style={styles.progressCard} onLayout={onProgressLayout}>
+          <Text style={styles.progressCentered}>
+            Progress: {moduleData.completed_submodules}/{moduleData.total_submodules} modules completed
           </Text>
-          <View style={styles.progressBarContainer}>
-            <View style={styles.progressBar}>
-              <View style={[styles.progressFill, { width: `${moduleData.progress_percent}%` }]} />
-            </View>
+          <View style={styles.progressBar}>
+            <View style={[styles.progressFill, { width: `${moduleData.progress_percent}%` }]} />
           </View>
         </View>
 
-        {/* Learning Pathway */}
-        <View style={styles.pathwayContainer} onLayout={onContainerLayout}>
-          {/* SVG Connecting Path behind items */}
-          <TrackPath
-            width={containerWidth}
-            height={containerHeight}
-            anchors={anchorsRef.current}
-            frames={displaySubmodules.map((_, i) => {
-              const rowTop = rowTopsRef.current[i];
-              const box = cardBoxesRef.current[i];
-              if (rowTop == null || !box) return undefined;
-              const framePad = 12;
-              const top = rowTop + box.relY - framePad;
-              const bottom = rowTop + box.relY + box.height + framePad;
-              return { top, bottom };
-            })}
-            tick={layoutTick}
+        {/* Rail container */}
+        <View style={styles.railContainer}>
+          {/* Black rail that starts at the bottom center of the progress card */}
+          <View
+            pointerEvents="none"
+            style={[
+              styles.rail,
+              {
+                top: progressBottom,
+                height: railHeight,
+                left: SCREEN_WIDTH / 2 - RAIL_W / 2,
+              },
+            ]}
           />
 
-          {displaySubmodules.map((m, i) => {
-            const iconOnRight = i % 2 === 0; // alternate sides
-            return (
-              <View
-                key={m.id}
-                style={[styles.pathwayItem]}
-                onLayout={e => {
-                  const { y } = e.nativeEvent.layout;
-                  setRowTopAndAnchor(i, y);
-                }}
-              >
-                {/* Module Card */}
-                <TouchableOpacity
-                  style={[
-                    styles.moduleCard,
-                    iconOnRight ? styles.cardShiftRight : styles.cardShiftLeft,
-                    m.status === 'completed' && styles.completedCard,
-                  ]}
-                  onLayout={e => {
-                    const { y, height } = e.nativeEvent.layout;
-                    setCardBox(i, y, height);
-                  }}
-                  onPress={() => {
-                    router.push({
-                      pathname: '/(tabs)/Learn/modules/[moduleId]/[submoduleId]' as any,
-                      params: { moduleId, submoduleId: m.id },
-                    });
-                  }}
-                >
-                  <View style={styles.moduleContent}>
-                    <Text style={styles.moduleNumberText}>
-                      Module {m.moduleNumber} • {m.stages} lessons
-                    </Text>
-                    <Text style={styles.moduleTitle}>{m.title}</Text>
-                    <View style={styles.moduleProgressLine} />
-                  </View>
-                </TouchableOpacity>
+          {/* Timeline items */}
+          <View style={styles.timelineList}>
+            {submodules.map((m, i) => {
+              const leftSide = i % 2 === 0;
+              const ctaText = m.is_completed ? 'Review' : m.progress_percent > 0 ? 'Resume' : 'Start';
+              const disabled = !m.unlocked;
+              const bubbleText = m.is_completed ? null : `${Math.round(m.progress_percent)}%`;
 
-                {/* Module Icon */}
+              return (
                 <View
-                  style={[
-                    styles.moduleIcon,
-                    iconOnRight ? styles.iconRight : styles.iconLeft,
-                    m.status === 'completed' && styles.completedIcon,
-                  ]}
+                  key={m.id}
+                  style={styles.timelineRow}
+                  onLayout={e => updateRowBottom(e.nativeEvent.layout.y + e.nativeEvent.layout.height)}
                 >
-                  {m.status === 'completed' ? (
-                    <Feather name='check' size={20} color='#fff' />
-                  ) : (
-                    <Text style={styles.iconEmoji}>{getModuleIcon(m.title)}</Text>
-                  )}
+                  {/* per-row upward line segment (same thickness as rail) */}
+                  <View
+                    pointerEvents="none"
+                    style={[
+                      styles.rowSegment,
+                      { left: SCREEN_WIDTH / 2 - RAIL_W / 2 },
+                    ]}
+                  />
+
+                  {/* Submodule card */}
+                  <TouchableOpacity
+                    activeOpacity={disabled ? 1 : 0.9}
+                    onPress={() => {
+                      if (disabled) return;
+                      router.push({
+                        pathname: '/(tabs)/Learn/modules/[moduleId]/[submoduleId]' as any,
+                        params: { moduleId, submoduleId: m.id },
+                      });
+                    }}
+                    style={[
+                      styles.card,
+                      leftSide ? styles.cardLeft : styles.cardRight,
+                      m.status === 'completed' && styles.cardCompleted,
+                    ]}
+                  >
+                    {/* status pill */}
+                    <View
+                      style={[
+                        styles.pill,
+                        m.status === 'completed'
+                          ? styles.pillCompleted
+                          : m.status === 'in-progress'
+                          ? styles.pillInProgress
+                          : styles.pillNotStarted,
+                      ]}
+                    >
+                      <Text
+                        style={[
+                          styles.pillText,
+                          m.status === 'completed'
+                            ? styles.pillTextCompleted
+                            : m.status === 'in-progress'
+                            ? styles.pillTextInProgress
+                            : styles.pillTextNotStarted,
+                        ]}
+                      >
+                        {m.status === 'completed'
+                          ? 'Completed'
+                          : m.status === 'in-progress'
+                          ? 'In Progress'
+                          : 'Not Started'}
+                      </Text>
+                    </View>
+
+                    <Text style={styles.cardTitle}>{m.title}</Text>
+                    {!!m.description && <Text style={styles.cardDesc}>{m.description}</Text>}
+
+                    {/* Centered, large CTA (shorter height) */}
+                    <View style={styles.ctaRow}>
+                      <View style={[styles.cta, (!m.is_completed && disabled) && styles.ctaDisabled]}>
+                        <Text style={styles.ctaText}>{ctaText}</Text>
+                      </View>
+                    </View>
+                  </TouchableOpacity>
+
+                  {/* Bubble: centered vertically, alternating side */}
+                  <View
+                    style={[
+                      styles.bubbleAbs,
+                      leftSide
+                        ? { left: SCREEN_WIDTH / 2 + RAIL_OFFSET }
+                        : { right: SCREEN_WIDTH / 2 + RAIL_OFFSET - SCREEN_WIDTH },
+                    ]}
+                  >
+                    <View
+                      style={[
+                        styles.bubbleOuter,
+                        (m.unlocked ? styles.bubbleOuterActive : styles.bubbleOuterInactive),
+                        m.is_completed && styles.bubbleDoneOuter,
+                      ]}
+                    >
+                      <View
+                        style={[
+                          styles.bubbleInner,
+                          (m.unlocked ? styles.bubbleInnerActive : styles.bubbleInnerInactive),
+                          m.is_completed && styles.bubbleDoneInner,
+                        ]}
+                      >
+                        {m.is_completed ? (
+                          <Feather name="check" size={18} color="#fff" />
+                        ) : (
+                          <Text style={styles.bubbleText}>{bubbleText}</Text>
+                        )}
+                      </View>
+                    </View>
+                  </View>
                 </View>
-              </View>
-            );
-          })}
+              );
+            })}
+          </View>
         </View>
+
+        <View style={{ height: 28 }} />
       </ScrollView>
     </SafeAreaView>
   );
 }
 
-const { width } = Dimensions.get('window');
-const ICON_SIZE = 48;
-
-// Renders an SVG path that alternates between left and right rails through given anchors
-function TrackPath({ width, height, anchors, frames, tick }: { width: number; height: number; anchors: number[]; frames: Array<{ top: number; bottom: number } | undefined>; tick: number }) {
-  const path = useMemo(() => {
-    if (!width || !height || !anchors?.length) return '';
-
-    const padding = 20;
-    const railLeft = padding + ICON_SIZE / 2 + 8; // icon center left
-    const railRight = width - padding - ICON_SIZE / 2 - 8; // icon center right
-
-    let d = '';
-    let currentX = railRight; // start at first icon on right rail
-    let currentY = anchors[0];
-    d += `M ${currentX} ${currentY}`;
-
-    const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
-
-    for (let i = 0; i < anchors.length - 1; i++) {
-      const yi = anchors[i];
-      const yj = anchors[i + 1];
-      const isRight = i % 2 === 0;
-      const railS = isRight ? railRight : railLeft; // current item rail
-      const railT = isRight ? railLeft : railRight; // next item rail
-
-      // Move to correct rail and the exact anchor for item i
-      if (currentX !== railS) d += ` H ${railS}`;
-      if (currentY !== yi) d += ` V ${yi}`;
-      currentX = railS; currentY = yi;
-
-      // Pick a safe Y to cross horizontally between cards
-      const fCur = frames?.[i];
-      const fNext = frames?.[i + 1];
-      const gap = 12;
-      let crossTop = fCur ? fCur.bottom + gap : Math.min(yi, yj) + Math.abs(yj - yi) * 0.4;
-      let crossBottom = fNext ? fNext.top - gap : Math.max(yi, yj) - Math.abs(yj - yi) * 0.4;
-      if (crossTop > crossBottom) {
-        // fallback to midpoint if overlap
-        const mid = (yi + yj) / 2;
-        crossTop = mid; crossBottom = mid;
-      }
-      let crossY = clamp((crossTop + crossBottom) / 2, Math.min(yi, yj) + 4, Math.max(yi, yj) - 4);
-
-      // Draw orthogonal L: down/up to crossY, across to other rail, down/up to next anchor
-      d += ` V ${crossY}`;
-      d += ` H ${railT}`;
-      d += ` V ${yj}`;
-      currentX = railT; currentY = yj;
-    }
-
-    return d;
-  }, [width, height, anchors, frames, tick]);
-
-  if (!path) return null;
-
-  return (
-    <Svg pointerEvents="none" style={StyleSheet.absoluteFill} width={width} height={height}>
-      <Path d={path} stroke="#E5E7EB" strokeWidth={10} fill="none" strokeLinejoin="miter" strokeLinecap="butt" />
-      <Path d={path} stroke="#FFFFFF" strokeWidth={6} fill="none" strokeLinejoin="miter" strokeLinecap="butt" />
-    </Svg>
-  );
-}
+/* ===================== styles ===================== */
 
 const styles = StyleSheet.create({
-  safe: { 
-    flex: 1, 
-    backgroundColor: '#F8F9FA' 
-  },
-  container: { 
-    paddingHorizontal: 20, 
-    paddingBottom: 40,
-    minHeight: '100%'
-  },
-  
-  // Header
-  headerRow: { 
-    flexDirection: 'row', 
-    alignItems: 'center',
-    marginTop: 10,
-    marginBottom: 20
-  },
-  backButton: { 
-    padding: 8,
-    marginLeft: -8
-  },
+  safe: { flex: 1, backgroundColor: '#F7F7F9' },
+  container: { paddingHorizontal: EDGE_PAD, paddingBottom: 40 },
 
-  // Title Section
-  titleSection: {
+  headerRow: {
+    flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 24
+    justifyContent: 'space-between',
+    paddingTop: 8,
+    marginBottom: 6,
   },
-  title: { 
-    fontSize: 32, 
-    fontWeight: '700', 
-    textAlign: 'center', 
-    color: '#1A1A1A',
-    marginBottom: 12,
-    lineHeight: 38
-  },
-  description: { 
-    fontSize: 16, 
-    textAlign: 'center', 
-    color: '#6B7280', 
-    lineHeight: 24,
-    paddingHorizontal: 20,
-    maxWidth: width - 40
-  },
-  
-  // Progress Card
+  backButton: { padding: 8 },
+
+  titleWrap: { alignItems: 'center', marginBottom: 8 },
+  title: { fontSize: 28, fontWeight: '800', color: '#151515', marginBottom: 6, textAlign: 'center' },
+  subtitle: { fontSize: 15, color: '#6B7280', textAlign: 'center', paddingHorizontal: 12 },
+
   progressCard: {
     backgroundColor: '#fff',
     borderRadius: 16,
-    padding: 20,
-    marginBottom: 32,
+    paddingVertical: 16,
+    paddingHorizontal: 16,
+    marginTop: 10,
+    marginBottom: 12,
     shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 3
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 6,
+    elevation: 1,
+    alignItems: 'center',
   },
-  progressText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#374151',
-    marginBottom: 12
-  },
-  progressBarContainer: {
-    width: '100%'
-  },
-  progressBar: { 
-    height: 8, 
-    backgroundColor: '#E5E7EB', 
-    borderRadius: 4, 
-    overflow: 'hidden' 
-  },
-  progressFill: { 
-    height: '100%', 
-    backgroundColor: '#10B981', 
-    borderRadius: 4 
+  progressCentered: { fontSize: 15, fontWeight: '700', color: '#374151', marginBottom: 10, textAlign: 'center' },
+  progressBar: { width: '100%', height: 8, backgroundColor: '#E5E7EB', borderRadius: 6, overflow: 'hidden' },
+  progressFill: { height: '100%', backgroundColor: '#111', borderRadius: 6 },
+
+  railContainer: { position: 'relative' },
+  rail: { position: 'absolute', width: RAIL_W, backgroundColor: '#111', borderRadius: 2 },
+
+  timelineList: { paddingTop: 6 },
+  timelineRow: { position: 'relative', marginVertical: 22, minHeight: 120 },
+
+  rowSegment: {
+    position: 'absolute',
+    top: -28,
+    height: 28,
+    width: RAIL_W,
+    backgroundColor: '#111',
+    borderRadius: 2,
   },
 
-  // Learning Pathway
-  pathwayContainer: {
-  marginTop: 8,
-  paddingBottom: 24,
-  // Make sure children render above the path
-  // backgroundColor: 'rgba(255,0,0,0.02)'
-  },
-  pathwayTitle: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: '#1A1A1A',
-    marginBottom: 24
-  },
-  pathwayItem: {
-    position: 'relative',
-  marginBottom: 24,
-  paddingTop: 8,
-  },
-
-  // Module Card
-  moduleCard: {
+  card: {
+    width: CARD_W,
     backgroundColor: '#fff',
     borderRadius: 16,
-    padding: 20,
-    // dynamic horizontal shift via cardShiftRight/Left
+    padding: 18,
     shadowColor: '#000',
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.08,
     shadowRadius: 12,
     elevation: 2,
     borderWidth: 1,
-    borderColor: '#F3F4F6'
+    borderColor: '#EEF2F7',
   },
-  cardShiftRight: {
-    marginRight: ICON_SIZE + 36,
-    marginLeft: 0,
-  },
-  cardShiftLeft: {
-    marginLeft: ICON_SIZE + 36,
-    marginRight: 0,
-  },
-  completedCard: {
-    backgroundColor: '#F0FDF4',
-    borderColor: '#BBF7D0'
-  },
-  moduleContent: {
-    flex: 1
-  },
-  moduleNumberText: {
-    fontSize: 14,
-    fontWeight: '500',
-    color: '#6B7280',
-    marginBottom: 8
-  },
-  moduleTitle: {
-    fontSize: 18,
-    fontWeight: '700',
-    color: '#1A1A1A',
-    marginBottom: 12,
-    lineHeight: 24
-  },
-  moduleProgressLine: {
-    height: 2,
-    backgroundColor: '#E5E7EB',
-    borderRadius: 1,
-    width: 40
-  },
+  cardLeft: { marginLeft: EDGE_PAD, alignSelf: 'flex-start' },
+  cardRight: { marginRight: EDGE_PAD, alignSelf: 'flex-end' },
+  cardCompleted: { backgroundColor: '#F0FDF4', borderColor: '#BBF7D0' },
 
-  // Module Icon
-  moduleIcon: {
-    position: 'absolute',
-    top: 20,
-    width: ICON_SIZE,
-    height: ICON_SIZE,
-    borderRadius: ICON_SIZE / 2,
-    backgroundColor: '#F3F4F6',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: 2,
-    borderColor: '#E5E7EB'
-  },
-  iconRight: { right: 20 },
-  iconLeft: { left: 20 },
-  completedIcon: {
-    backgroundColor: '#10B981',
-    borderColor: '#059669'
-  },
-  iconEmoji: {
-    fontSize: 24
-  },
+  pill: { alignSelf: 'flex-start', paddingHorizontal: 12, paddingVertical: 5, borderRadius: 999, marginBottom: 10 },
+  pillCompleted: { backgroundColor: '#DCFCE7' },
+  pillInProgress: { backgroundColor: '#E0E7FF' },
+  pillNotStarted: { backgroundColor: '#F3F4F6' },
+  pillText: { fontSize: 13, fontWeight: '800' },
+  pillTextCompleted: { color: '#166534' },
+  pillTextInProgress: { color: '#3730A3' },
+  pillTextNotStarted: { color: '#6B7280' },
 
-  // Connecting Path (replaced by SVG TrackPath)
+  cardTitle: { fontSize: 18, fontWeight: '800', color: '#111827', marginBottom: 10 },
+  cardDesc: { fontSize: 14, color: '#6B7280', marginBottom: 14 },
 
-  // Loading and Error States
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 20,
-  },
-  loadingText: {
-    fontSize: 16,
-    color: '#6B7280',
-    textAlign: 'center',
-  },
-  errorText: {
-    fontSize: 16,
-    color: '#EF4444',
-    textAlign: 'center',
-  },
+  ctaRow: { alignItems: 'center' },
+  cta: { alignSelf: 'stretch', backgroundColor: '#111', paddingVertical: 10, borderRadius: 999, alignItems: 'center' },
+  ctaDisabled: { backgroundColor: '#A9B1BC' },
+  ctaText: { color: '#fff', fontSize: 16, fontWeight: '800' },
+
+  bubbleAbs: { position: 'absolute', top: 0, bottom: 0, justifyContent: 'center', alignItems: 'center' },
+  bubbleOuter: { width: 54, height: 54, borderRadius: 27, alignItems: 'center', justifyContent: 'center', borderWidth: 2 },
+  bubbleOuterActive: { borderColor: '#AAB2BF' },
+  bubbleOuterInactive: { borderColor: '#D1D6DF' },
+  bubbleInner: { width: 44, height: 44, borderRadius: 22, alignItems: 'center', justifyContent: 'center' },
+  bubbleInnerActive: { backgroundColor: '#959DAC' },
+  bubbleInnerInactive: { backgroundColor: '#E2E6EE' },
+  bubbleDoneOuter: { borderColor: '#059669' },
+  bubbleDoneInner: { backgroundColor: '#10B981' },
+  bubbleText: { fontSize: 13, fontWeight: '800', color: '#fff' },
+
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
+  muted: { fontSize: 16, color: '#6B7280' },
+  error: { fontSize: 16, color: '#EF4444' },
 });
-

--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/index.tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -8,19 +8,35 @@ import {
   ScrollView,
   Dimensions,
   LayoutChangeEvent,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
 } from 'react-native';
 import { useRouter, useLocalSearchParams, Link } from 'expo-router';
 import { useModule } from '@/hooks/learn/useModule';
 import { Feather } from '@expo/vector-icons';
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
+// --- safety helpers ---
+const safeNum = (n: any, fallback = 0) =>
+  Number.isFinite(Number(n)) ? Number(n) : fallback;
+const clampNonNeg = (n: any) => Math.max(0, safeNum(n, 0));
+
+// screen + layout constants
+const { width: RAW_WIDTH } = Dimensions.get('window');
+const SCREEN_WIDTH = Math.max(1, safeNum(RAW_WIDTH, 1));
 
 const EDGE_PAD = 16;
-const CONTENT_W = SCREEN_WIDTH - EDGE_PAD * 2;
-const CARD_RATIO = 0.75;
-const CARD_W = Math.min(420, Math.floor(CONTENT_W * CARD_RATIO));
-const RAIL_W = 4; 
-const RAIL_OFFSET = 30; 
+const CONTENT_W = Math.max(0, SCREEN_WIDTH - EDGE_PAD * 2);
+
+// Card size
+const CARD_RATIO = 0.68;
+const CARD_W = Math.max(1, Math.min(380, Math.floor(CONTENT_W * CARD_RATIO) || 1));
+
+const RAIL_W = 4;
+
+// Bubble sizing + gap (distance from card edge to bubble)
+const BUBBLE_SIZE = 70;                // change to resize circle
+const BUBBLE_RADIUS = BUBBLE_SIZE / 2;
+const BUBBLE_GAP = 25;                 // change to move closer/farther from card
 
 export default function ModuleIndex() {
   const router = useRouter();
@@ -31,22 +47,32 @@ export default function ModuleIndex() {
   const [progressBottom, setProgressBottom] = useState(0);
   const [railEnd, setRailEnd] = useState<number | null>(null);
 
+  // visibility tracking
+  const rowTopsRef = useRef<number[]>([]);
+  const [ahead, setAhead] = useState(0);
+
+  // per-row card layout (for bubble X/Y position)
+  const cardLayoutsRef = useRef<Array<{ x: number; y: number; width: number; height: number }>>([]);
+
   const onProgressLayout = (e: LayoutChangeEvent) => {
-    const { y, height } = e.nativeEvent.layout;
-    setProgressBottom(y + height);
+    const y = clampNonNeg(e.nativeEvent.layout.y);
+    const h = clampNonNeg(e.nativeEvent.layout.height);
+    setProgressBottom(y + h);
   };
 
   const updateRowBottom = (bottom: number) =>
-    setRailEnd(prev => (prev == null ? bottom : Math.max(prev, bottom)));
-
+    setRailEnd(prev => {
+      const b = clampNonNeg(bottom);
+      if (!Number.isFinite(b)) return prev ?? 0;
+      return prev == null ? b : Math.max(prev, b);
+    });
 
   const railHeight = useMemo(() => {
-    if (!railEnd || progressBottom <= 0) return 0;
-    const trim = 18; // stop a bit before the last card
+    if (railEnd == null || progressBottom <= 0) return 0;
+    const trim = 18;
     return Math.max(0, railEnd - progressBottom - trim);
   }, [railEnd, progressBottom]);
 
- 
   if (isLoading) {
     return (
       <SafeAreaView style={styles.safe}>
@@ -66,17 +92,59 @@ export default function ModuleIndex() {
     );
   }
 
-  // Normalize list + gating (unlock i if i==0 or previous completed)
+  // Normalize list + gating
   const submodules = moduleData.submodules.map((s, i, arr) => {
     const status = s.is_completed ? 'completed' : s.progress_percent > 0 ? 'in-progress' : 'not-started';
     const unlocked = i === 0 || !!arr[i - 1]?.is_completed;
     return { ...s, index: i + 1, status, unlocked };
   });
 
+  // compute "ahead" on every scroll
+  const handleScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const y = clampNonNeg(e.nativeEvent.contentOffset?.y);
+    const vh = clampNonNeg(e.nativeEvent.layoutMeasurement?.height);
+    const visibleBottom = y + vh;
+    const buffer = 4;
+    const below = rowTopsRef.current.filter((v) => Number.isFinite(v) && v > visibleBottom + buffer).length;
+    setAhead(below);
+  };
+
+  // ========== Bubble helpers ==========
+  // Bubble to the LEFT of a card (outside, hugging its left edge)
+  const bubbleOutsideLeftOfCard = (index: number, fallbackLeftEdge: number) => {
+    const entry = cardLayoutsRef.current[index];
+    const cardLeft = (entry && Number.isFinite(entry.x)) ? entry.x : fallbackLeftEdge;
+    return Math.max(0, cardLeft - BUBBLE_GAP - 2 * BUBBLE_RADIUS);
+  };
+
+  // Bubble to the RIGHT of a card (outside, hugging its right edge)
+  const bubbleOutsideRightOfCard = (index: number, fallbackRightEdge: number) => {
+    const entry = cardLayoutsRef.current[index];
+    const cardRight = (entry && Number.isFinite(entry.x) && Number.isFinite(entry.width))
+      ? entry.x + entry.width
+      : fallbackRightEdge;
+    return Math.max(0, cardRight + BUBBLE_GAP);
+  };
+
+  // Vertically center the bubble to the CARD
+  const bubbleTopForCard = (index: number, fallbackRowTop: number, fallbackRowHeight: number) => {
+    const entry = cardLayoutsRef.current[index];
+    if (entry && Number.isFinite(entry.y) && Number.isFinite(entry.height)) {
+      return Math.max(0, entry.y + (entry.height - BUBBLE_SIZE) / 2);
+    }
+    // fallback: center in the row until we get card layout
+    return Math.max(0, fallbackRowTop + (fallbackRowHeight - BUBBLE_SIZE) / 2);
+  };
+
   return (
     <SafeAreaView style={styles.safe}>
-      <ScrollView contentContainerStyle={styles.container} showsVerticalScrollIndicator={false}>
-        {/* Header (no "unify" text here) */}
+      <ScrollView
+        contentContainerStyle={styles.container}
+        showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+      >
+        {/* Header */}
         <View style={styles.headerRow}>
           <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
             <Feather name='arrow-left' size={26} color='#111' />
@@ -104,34 +172,49 @@ export default function ModuleIndex() {
 
         {/* Rail container */}
         <View style={styles.railContainer}>
-          {/* Black rail that starts at the bottom center of the progress card */}
-          <View
-            pointerEvents="none"
-            style={[
-              styles.rail,
-              {
-                top: progressBottom,
-                height: railHeight,
-                left: SCREEN_WIDTH / 2 - RAIL_W / 2,
-              },
-            ]}
-          />
+          {/* Rail */}
+          {railHeight > 0 && (
+            <View
+              pointerEvents="none"
+              style={[
+                styles.rail,
+                {
+                  top: progressBottom,
+                  height: railHeight,
+                  left: SCREEN_WIDTH / 2 - RAIL_W / 2,
+                },
+              ]}
+            />
+          )}
 
           {/* Timeline items */}
           <View style={styles.timelineList}>
             {submodules.map((m, i) => {
-              const leftSide = i % 2 === 0;
+              const leftSide = i % 2 === 0; // card sits on the left?
               const ctaText = m.is_completed ? 'Review' : m.progress_percent > 0 ? 'Resume' : 'Start';
               const disabled = !m.unlocked;
               const bubbleText = m.is_completed ? null : `${Math.round(m.progress_percent)}%`;
+
+              // Fallback edges until card onLayout fires
+              const fallbackLeftEdgeOfRightCard  = SCREEN_WIDTH - EDGE_PAD - CARD_W; // right-aligned card's LEFT
+              const fallbackRightEdgeOfLeftCard  = EDGE_PAD + CARD_W;                 // left-aligned card's RIGHT
+
+              // Row layout (for fallback top)
+              let rowTop = 0;
+              let rowHeight = 0;
 
               return (
                 <View
                   key={m.id}
                   style={styles.timelineRow}
-                  onLayout={e => updateRowBottom(e.nativeEvent.layout.y + e.nativeEvent.layout.height)}
+                  onLayout={e => {
+                    rowTop = clampNonNeg(e.nativeEvent.layout.y);
+                    rowHeight = clampNonNeg(e.nativeEvent.layout.height);
+                    rowTopsRef.current[i] = rowTop;
+                    updateRowBottom(rowTop + rowHeight);
+                  }}
                 >
-                  {/* per-row upward line segment (same thickness as rail) */}
+                  {/* per-row upward line segment */}
                   <View
                     pointerEvents="none"
                     style={[
@@ -153,16 +236,25 @@ export default function ModuleIndex() {
                     style={[
                       styles.card,
                       leftSide ? styles.cardLeft : styles.cardRight,
-                      m.status === 'completed' && styles.cardCompleted,
+                      (m as any).status === 'completed' && styles.cardCompleted,
                     ]}
+                    onLayout={(ev) => {
+                      const { x, y, width, height } = ev.nativeEvent.layout;
+                      cardLayoutsRef.current[i] = {
+                        x: Math.max(0, x),
+                        y: Math.max(0, y),
+                        width: Math.max(0, width),
+                        height: Math.max(0, height),
+                      };
+                    }}
                   >
-                    {/* status pill */}
+                    {/* status chip */}
                     <View
                       style={[
                         styles.pill,
-                        m.status === 'completed'
+                        (m as any).status === 'completed'
                           ? styles.pillCompleted
-                          : m.status === 'in-progress'
+                          : (m as any).status === 'in-progress'
                           ? styles.pillInProgress
                           : styles.pillNotStarted,
                       ]}
@@ -170,16 +262,16 @@ export default function ModuleIndex() {
                       <Text
                         style={[
                           styles.pillText,
-                          m.status === 'completed'
+                          (m as any).status === 'completed'
                             ? styles.pillTextCompleted
-                            : m.status === 'in-progress'
+                            : (m as any).status === 'in-progress'
                             ? styles.pillTextInProgress
                             : styles.pillTextNotStarted,
                         ]}
                       >
-                        {m.status === 'completed'
+                        {(m as any).status === 'completed'
                           ? 'Completed'
-                          : m.status === 'in-progress'
+                          : (m as any).status === 'in-progress'
                           ? 'In Progress'
                           : 'Not Started'}
                       </Text>
@@ -188,7 +280,7 @@ export default function ModuleIndex() {
                     <Text style={styles.cardTitle}>{m.title}</Text>
                     {!!m.description && <Text style={styles.cardDesc}>{m.description}</Text>}
 
-                    {/* Centered, large CTA (shorter height) */}
+                    {/* CTA */}
                     <View style={styles.ctaRow}>
                       <View style={[styles.cta, (!m.is_completed && disabled) && styles.ctaDisabled]}>
                         <Text style={styles.ctaText}>{ctaText}</Text>
@@ -196,31 +288,40 @@ export default function ModuleIndex() {
                     </View>
                   </TouchableOpacity>
 
-                  {/* Bubble: centered vertically, alternating side */}
+                  {/* Bubble: rail-side of each card, centered to the card */}
                   <View
+                    pointerEvents="none"
                     style={[
                       styles.bubbleAbs,
-                      leftSide
-                        ? { left: SCREEN_WIDTH / 2 + RAIL_OFFSET }
-                        : { right: SCREEN_WIDTH / 2 + RAIL_OFFSET - SCREEN_WIDTH },
+                      {
+                        left: leftSide
+                          ? bubbleOutsideRightOfCard(i, fallbackRightEdgeOfLeftCard)
+                          : bubbleOutsideLeftOfCard(i, fallbackLeftEdgeOfRightCard),
+                        top: bubbleTopForCard(
+                          i,
+                          rowTop,
+                          rowHeight
+                        ),
+                        opacity: cardLayoutsRef.current[i] ? 1 : 0, // avoid visible jump before layout
+                      },
                     ]}
                   >
                     <View
                       style={[
                         styles.bubbleOuter,
-                        (m.unlocked ? styles.bubbleOuterActive : styles.bubbleOuterInactive),
+                        (m.unlocked ? styles.bubbleOuterActive : styles.bubbleOuterBlocked),
                         m.is_completed && styles.bubbleDoneOuter,
                       ]}
                     >
                       <View
                         style={[
                           styles.bubbleInner,
-                          (m.unlocked ? styles.bubbleInnerActive : styles.bubbleInnerInactive),
+                          (m.unlocked ? styles.bubbleInnerActive : styles.bubbleInnerBlocked),
                           m.is_completed && styles.bubbleDoneInner,
                         ]}
                       >
                         {m.is_completed ? (
-                          <Feather name="check" size={18} color="#fff" />
+                          <Feather name="check" size={20} color="#fff" />
                         ) : (
                           <Text style={styles.bubbleText}>{bubbleText}</Text>
                         )}
@@ -235,13 +336,26 @@ export default function ModuleIndex() {
 
         <View style={{ height: 28 }} />
       </ScrollView>
+
+      {/* floating "N more modules ahead" pill */}
+      {ahead > 0 && (
+        <View style={styles.morePillWrap} pointerEvents="none">
+          <View style={styles.morePill}>
+            <View style={styles.dots}>
+              <View style={styles.dot} />
+              <View style={styles.dot} />
+              <View style={styles.dot} />
+            </View>
+            <Text style={styles.moreText}>{ahead} more modules ahead</Text>
+          </View>
+        </View>
+      )}
     </SafeAreaView>
   );
 }
 
-
 const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: '#F7F7F9' },
+  safe: { flex: 1, backgroundColor: '#F7F7F9', position: 'relative' },
   container: { paddingHorizontal: EDGE_PAD, paddingBottom: 40 },
 
   headerRow: {
@@ -253,15 +367,16 @@ const styles = StyleSheet.create({
   },
   backButton: { padding: 8 },
 
+  // Header text
   titleWrap: { alignItems: 'center', marginBottom: 8 },
-  title: { fontSize: 28, fontWeight: '800', color: '#151515', marginBottom: 6, textAlign: 'center' },
-  subtitle: { fontSize: 15, color: '#6B7280', textAlign: 'center', paddingHorizontal: 12 },
+  title: { fontSize: 40, fontWeight: '900', color: '#151515', marginBottom: 5, textAlign: 'center' },
+  subtitle: { fontSize: 20, color: '#4B5563', textAlign: 'center', paddingHorizontal: 12 },
 
   progressCard: {
     backgroundColor: '#fff',
     borderRadius: 16,
-    paddingVertical: 16,
-    paddingHorizontal: 16,
+    paddingVertical: 14,
+    paddingHorizontal: 14,
     marginTop: 10,
     marginBottom: 12,
     shadowColor: '#000',
@@ -271,7 +386,7 @@ const styles = StyleSheet.create({
     elevation: 1,
     alignItems: 'center',
   },
-  progressCentered: { fontSize: 15, fontWeight: '700', color: '#374151', marginBottom: 10, textAlign: 'center' },
+  progressCentered: { fontSize: 17, fontWeight: '700', color: '#374151', marginBottom: 10, textAlign: 'center' },
   progressBar: { width: '100%', height: 8, backgroundColor: '#E5E7EB', borderRadius: 6, overflow: 'hidden' },
   progressFill: { height: '100%', backgroundColor: '#111', borderRadius: 6 },
 
@@ -279,27 +394,28 @@ const styles = StyleSheet.create({
   rail: { position: 'absolute', width: RAIL_W, backgroundColor: '#111', borderRadius: 2 },
 
   timelineList: { paddingTop: 6 },
-  timelineRow: { position: 'relative', marginVertical: 22, minHeight: 120 },
+  timelineRow: { position: 'relative', marginVertical: 18, minHeight: 110 },
 
   rowSegment: {
     position: 'absolute',
-    top: -28,
-    height: 28,
+    top: -24,
+    height: 24,
     width: RAIL_W,
     backgroundColor: '#111',
     borderRadius: 2,
   },
 
+  // Card
   card: {
     width: CARD_W,
     backgroundColor: '#fff',
-    borderRadius: 16,
-    padding: 18,
+    borderRadius: 14,
+    padding: 14,
     shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.08,
-    shadowRadius: 12,
-    elevation: 2,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.06,
+    shadowRadius: 10,
+    elevation: 1,
     borderWidth: 1,
     borderColor: '#EEF2F7',
   },
@@ -307,33 +423,95 @@ const styles = StyleSheet.create({
   cardRight: { marginRight: EDGE_PAD, alignSelf: 'flex-end' },
   cardCompleted: { backgroundColor: '#F0FDF4', borderColor: '#BBF7D0' },
 
-  pill: { alignSelf: 'flex-start', paddingHorizontal: 12, paddingVertical: 5, borderRadius: 999, marginBottom: 10 },
-  pillCompleted: { backgroundColor: '#DCFCE7' },
-  pillInProgress: { backgroundColor: '#E0E7FF' },
-  pillNotStarted: { backgroundColor: '#F3F4F6' },
-  pillText: { fontSize: 13, fontWeight: '800' },
+  // Status chip
+  pill: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    marginBottom: 10,
+    borderWidth: 1,
+  },
+  pillCompleted: { backgroundColor: '#ECFDF5', borderColor: '#C7F9DF' },
+  pillInProgress: { backgroundColor: '#F1F5F9', borderColor: '#E5E7EB' },
+  pillNotStarted: { backgroundColor: '#F1F5F9', borderColor: '#E5E7EB' },
+  pillText: { fontSize: 12, fontWeight: '800' },
   pillTextCompleted: { color: '#166534' },
-  pillTextInProgress: { color: '#3730A3' },
+  pillTextInProgress: { color: '#4B5563' },
   pillTextNotStarted: { color: '#6B7280' },
 
-  cardTitle: { fontSize: 18, fontWeight: '800', color: '#111827', marginBottom: 10 },
-  cardDesc: { fontSize: 14, color: '#6B7280', marginBottom: 14 },
+  cardTitle: { fontSize: 17, fontWeight: '800', color: '#111827', marginBottom: 8 },
+  cardDesc: { fontSize: 13, color: '#6B7280', marginBottom: 12 },
 
+  // CTA
   ctaRow: { alignItems: 'center' },
-  cta: { alignSelf: 'stretch', backgroundColor: '#111', paddingVertical: 10, borderRadius: 999, alignItems: 'center' },
-  ctaDisabled: { backgroundColor: '#A9B1BC' },
-  ctaText: { color: '#fff', fontSize: 16, fontWeight: '800' },
+  cta: {
+    alignSelf: 'stretch',
+    backgroundColor: '#111',
+    paddingVertical: 9,
+    borderRadius: 10,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#0f0f0f',
+  },
+  ctaDisabled: { backgroundColor: '#B8BFC9', borderColor: '#B8BFC9' },
+  ctaText: { color: '#fff', fontSize: 15, fontWeight: '800' },
 
-  bubbleAbs: { position: 'absolute', top: 0, bottom: 0, justifyContent: 'center', alignItems: 'center' },
-  bubbleOuter: { width: 54, height: 54, borderRadius: 27, alignItems: 'center', justifyContent: 'center', borderWidth: 2 },
+  // Bubble — absolute box; we set exact top/left inline per card
+  bubbleAbs: {
+    position: 'absolute',
+    width: BUBBLE_SIZE,
+    height: BUBBLE_SIZE,
+  },
+  bubbleOuter: {
+    width: BUBBLE_SIZE,
+    height: BUBBLE_SIZE,
+    borderRadius: BUBBLE_RADIUS,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+  },
   bubbleOuterActive: { borderColor: '#AAB2BF' },
-  bubbleOuterInactive: { borderColor: '#D1D6DF' },
-  bubbleInner: { width: 44, height: 44, borderRadius: 22, alignItems: 'center', justifyContent: 'center' },
+  bubbleOuterBlocked: { borderColor: '#9FA7B5' }, // darker blocked ring
+  bubbleInner: {
+    width: BUBBLE_SIZE - 10,
+    height: BUBBLE_SIZE - 10,
+    borderRadius: (BUBBLE_SIZE - 10) / 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   bubbleInnerActive: { backgroundColor: '#959DAC' },
-  bubbleInnerInactive: { backgroundColor: '#E2E6EE' },
+  bubbleInnerBlocked: { backgroundColor: '#C9CFDB' }, // darker blocked fill
   bubbleDoneOuter: { borderColor: '#059669' },
   bubbleDoneInner: { backgroundColor: '#10B981' },
-  bubbleText: { fontSize: 13, fontWeight: '800', color: '#fff' },
+  bubbleText: { fontSize: 20, fontWeight: '800', color: '#fff' },
+
+  // floating pill styles
+  morePillWrap: {
+    position: 'absolute',
+    bottom: 90,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+  },
+  morePill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    borderColor: '#D7DDE7',
+    borderWidth: 1,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 2,
+  },
+  dots: { flexDirection: 'row', marginRight: 10 },
+  dot: { width: 6, height: 6, borderRadius: 3, backgroundColor: '#C7CDD8', marginHorizontal: 2 },
+  moreText: { fontSize: 14, color: '#6B7280', fontWeight: '700' },
 
   centered: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
   muted: { fontSize: 16, color: '#6B7280' },

--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/index.tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/index.tsx
@@ -15,13 +15,12 @@ import { Feather } from '@expo/vector-icons';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
-/** layout constants */
 const EDGE_PAD = 16;
 const CONTENT_W = SCREEN_WIDTH - EDGE_PAD * 2;
-const CARD_RATIO = 0.75; // 75% width cards
+const CARD_RATIO = 0.75;
 const CARD_W = Math.min(420, Math.floor(CONTENT_W * CARD_RATIO));
-const RAIL_W = 4;        // unified thickness
-const RAIL_OFFSET = 30;  // distance from rail to bubble
+const RAIL_W = 4; 
+const RAIL_OFFSET = 30; 
 
 export default function ModuleIndex() {
   const router = useRouter();
@@ -40,14 +39,14 @@ export default function ModuleIndex() {
   const updateRowBottom = (bottom: number) =>
     setRailEnd(prev => (prev == null ? bottom : Math.max(prev, bottom)));
 
-  /** IMPORTANT: call hooks BEFORE any early returns */
+
   const railHeight = useMemo(() => {
     if (!railEnd || progressBottom <= 0) return 0;
     const trim = 18; // stop a bit before the last card
     return Math.max(0, railEnd - progressBottom - trim);
   }, [railEnd, progressBottom]);
 
-  // ---------------- early returns (after hooks) ----------------
+ 
   if (isLoading) {
     return (
       <SafeAreaView style={styles.safe}>
@@ -66,7 +65,6 @@ export default function ModuleIndex() {
       </SafeAreaView>
     );
   }
-  // --------------------------------------------------------------
 
   // Normalize list + gating (unlock i if i==0 or previous completed)
   const submodules = moduleData.submodules.map((s, i, arr) => {
@@ -241,7 +239,6 @@ export default function ModuleIndex() {
   );
 }
 
-/* ===================== styles ===================== */
 
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: '#F7F7F9' },


### PR DESCRIPTION
## Title
Sub-module-pathway UI fix

## Link
[Link](https://app.clickup.com/t/86ac8dqxv)

## What was done
The sub-module-map UI was redesigned to make cards and progress bubbles fully dynamic and the most similar to desing.
What was added:
- Dynamic rectangular submodule cards (alternating left/right)
- Status chip (“Not Started / In Progress / Completed”) inside each card
- Flatter call-to-action button (“Start / Resume / Review”)
- Progress bubbles on the rail side of each card
 - Bubble text (percent) or checkmark for completion
- Center vertical rail with short row connectors

**The only file that was edited was: /modules/[moduleID]/index.tsx**

I ran fine 'npm run format' and code builds with no errors.

Note: We might need to add in supabase a way of ordering the submodules, right now is just shown alphabetically

## Frontend Screenshots (if applicable)

| Before | After |
|--------|-------|
| <img width="300" alt="before" src="https://github.com/user-attachments/assets/dcf563bd-0dc1-4201-b83d-799a3bc87960" /> | <img width="300" alt="after" src="https://github.com/user-attachments/assets/2e96c2aa-35d9-44ef-866f-9b4b13017606" /> |

You can also add things in supabase in "Submodules" and it will appear xdd
- Supabase “Submodules” entry:  
  <img width="600" alt="supabase" src="https://github.com/user-attachments/assets/118d5a9d-09aa-4d45-a719-50ffbcf45715" />

- Final result in app:  
  <img width="300" alt="finalproof" src="https://github.com/user-attachments/assets/46bfe067-a8a2-45f7-82ea-9155b30c78d0" />


## Please make sure you did these
- Run 'npm run format' to prettier your changes (seriously please run it - bq)
- Code builds without errors
- No console errors

## Reminder
Please assign yourself this PR in the sidebar