### PR TITLE
feat: personalized daily tip card on Community tab

### DIFF
--- a/unify-front-end/app/_layout.tsx
+++ b/unify-front-end/app/_layout.tsx
@@ -154,6 +154,8 @@ function AppContent() {
       <Stack.Screen name='see-more-users' options={{ headerShown: false }} />
       <Stack.Screen name='news-detail' options={{ headerShown: false }} />
       <Stack.Screen name='news-tips' options={{ headerShown: false }} />
+      <Stack.Screen name='past-tips' options={{ headerShown: false }} />
+      <Stack.Screen name='tip-detail' options={{ headerShown: false }} />
       <Stack.Screen name='event-detail' options={{ headerShown: false }} />
       <Stack.Screen name='events' options={{ headerShown: false }} />
       <Stack.Screen name='create-post' options={{ headerShown: false }} />

--- a/unify-front-end/app/past-tips.tsx
+++ b/unify-front-end/app/past-tips.tsx
@@ -1,0 +1,117 @@
+import { StyleSheet, View, FlatList, Text } from 'react-native';
+import { useRouter } from 'expo-router';
+import BackHeader from '@/components/BackHeader';
+import { DailyTipCard } from '@/components/tips/DailyTipCard';
+import { DailyTip } from '@/types/dailyTip';
+import { Theme } from '@/constants/Theme';
+import { usePastTips } from '@/hooks/tips/usePastTips';
+import { useCurrentUser } from '@/context/UserContext';
+import { useOnboardingProfile } from '@/hooks/onboarding/useOnboardingProfile';
+import EmptyFeedMessage from '@/components/profile/EmptyFeedMessage';
+import { Feather } from '@expo/vector-icons';
+
+const PastTipsScreen = () => {
+  const router = useRouter();
+  const { currentUser } = useCurrentUser();
+  const { data: profile } = useOnboardingProfile(currentUser?.id);
+  const { data: tips, isLoading } = usePastTips(
+    profile?.persona ?? undefined,
+    profile?.stage ?? undefined
+  );
+
+  const renderTipCard = ({ item }: { item: DailyTip }) => (
+    <View style={styles.tipCardContainer}>
+      <DailyTipCard
+        tip={item}
+        onPress={() =>
+          router.push({
+            pathname: '/tip-detail' as any,
+            params: { tip: JSON.stringify(item) },
+          })
+        }
+      />
+    </View>
+  );
+
+  if (isLoading) {
+    return (
+      <View style={styles.container}>
+        <BackHeader title='Past Tips' />
+        <View style={styles.loadingContainer}>
+          <Text style={styles.loadingText}>Loading tips...</Text>
+        </View>
+      </View>
+    );
+  }
+
+  if (!tips || tips.length === 0) {
+    return (
+      <View style={styles.container}>
+        <BackHeader title='Past Tips' />
+        <View style={styles.emptyContainer}>
+          <EmptyFeedMessage
+            icon={<Feather name='sun' size={24} color='#B4B1B1' />}
+            message='No tips yet'
+            submessage={
+              <Text
+                style={{
+                  fontSize: 14,
+                  color: Theme.textInput,
+                  textAlign: 'center',
+                  lineHeight: 20,
+                }}
+              >
+                Check back tomorrow for your first daily tip!
+              </Text>
+            }
+          />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <BackHeader title='Past Tips' />
+      <FlatList
+        data={tips}
+        renderItem={renderTipCard}
+        keyExtractor={item => item.id}
+        contentContainerStyle={styles.listContent}
+        showsVerticalScrollIndicator={false}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Theme.white,
+  },
+  listContent: {
+    padding: 20,
+    gap: 16,
+  },
+  tipCardContainer: {
+    marginBottom: 16,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  loadingText: {
+    fontSize: 16,
+    color: Theme.textInput,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+});
+
+export default PastTipsScreen;

--- a/unify-front-end/app/tip-detail.tsx
+++ b/unify-front-end/app/tip-detail.tsx
@@ -1,0 +1,244 @@
+import { StyleSheet, View, Text, ScrollView, TouchableOpacity, Linking } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Feather } from '@expo/vector-icons';
+import BackHeader from '@/components/BackHeader';
+import { CATEGORY_CONFIG } from '@/components/tips/DailyTipCard';
+import { DailyTip } from '@/types/dailyTip';
+import { Theme } from '@/constants/Theme';
+
+const formatDate = (dateString: string): string => {
+  try {
+    const date = new Date(dateString + 'T00:00:00');
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  } catch {
+    return dateString;
+  }
+};
+
+const TipDetailScreen = () => {
+  const { tip } = useLocalSearchParams<{ tip: string }>();
+  const router = useRouter();
+
+  let tipData: DailyTip | null = null;
+  try {
+    tipData = tip ? JSON.parse(tip) : null;
+  } catch (error) {
+    console.error('Error parsing tip data:', error);
+  }
+
+  if (!tipData) {
+    return (
+      <View style={styles.container}>
+        <BackHeader title='' />
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorText}>Tip not found</Text>
+        </View>
+      </View>
+    );
+  }
+
+  const config = CATEGORY_CONFIG[tipData.category] || CATEGORY_CONFIG.general;
+
+  return (
+    <View style={styles.container}>
+      <BackHeader />
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.contentContainer}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Category Header */}
+        <LinearGradient
+          colors={config.gradient}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.categoryHeader}
+        >
+          <View style={[styles.iconCircle, { backgroundColor: config.accent + '18' }]}>
+            <Feather name={config.icon as any} size={24} color={config.accent} />
+          </View>
+          <View style={[styles.categoryBadge, { backgroundColor: config.accent + '14' }]}>
+            <Text style={[styles.categoryText, { color: config.accent }]}>
+              {tipData.category.charAt(0).toUpperCase() + tipData.category.slice(1)}
+            </Text>
+          </View>
+        </LinearGradient>
+
+        {/* Date */}
+        <Text style={styles.date}>{formatDate(tipData.date)}</Text>
+
+        {/* Title */}
+        <Text style={styles.title}>{tipData.title}</Text>
+
+        {/* Description */}
+        {tipData.description && (
+          <Text style={styles.description}>{tipData.description}</Text>
+        )}
+
+        <View style={styles.divider} />
+
+        {/* Full Tip Text */}
+        <Text style={styles.tipText}>{tipData.tipText}</Text>
+
+        {/* Source References */}
+        {tipData.sourceRefs && tipData.sourceRefs.length > 0 && (
+          <View style={styles.sourcesSection}>
+            <Text style={styles.sourcesTitle}>Sources</Text>
+            {tipData.sourceRefs.map((ref, index) => (
+              <TouchableOpacity
+                key={index}
+                onPress={() => {
+                  if (ref.url) {
+                    Linking.openURL(ref.url).catch(err =>
+                      console.error('Failed to open URL:', err)
+                    );
+                  }
+                }}
+                style={styles.sourceItem}
+              >
+                <Feather name='external-link' size={14} color={Theme.surfaceBlue} />
+                <Text style={styles.sourceText}>{ref.document_title}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        )}
+
+        {/* See Past Tips */}
+        <TouchableOpacity
+          style={styles.pastTipsButton}
+          onPress={() => router.push('/past-tips' as any)}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.pastTipsText}>See past tips</Text>
+          <Feather name='chevron-right' size={16} color={Theme.surfaceBlue} />
+        </TouchableOpacity>
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Theme.white,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  contentContainer: {
+    paddingBottom: 40,
+  },
+  categoryHeader: {
+    paddingHorizontal: 20,
+    paddingVertical: 24,
+    alignItems: 'center',
+    gap: 12,
+  },
+  iconCircle: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  categoryBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  categoryText: {
+    fontSize: 13,
+    fontWeight: '600',
+    letterSpacing: 0.3,
+  },
+  date: {
+    fontSize: 14,
+    color: Theme.textInput,
+    paddingHorizontal: 20,
+    marginTop: 20,
+    marginBottom: 8,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: Theme.black,
+    paddingHorizontal: 20,
+    marginBottom: 8,
+    lineHeight: 34,
+  },
+  description: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: Theme.textAlternateGray,
+    paddingHorizontal: 20,
+    lineHeight: 22,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: Theme.surfaceGray,
+    marginHorizontal: 20,
+    marginVertical: 20,
+  },
+  tipText: {
+    fontSize: 18,
+    color: Theme.black,
+    paddingHorizontal: 20,
+    lineHeight: 28,
+  },
+  sourcesSection: {
+    paddingHorizontal: 20,
+    marginTop: 28,
+  },
+  sourcesTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Theme.textInput,
+    marginBottom: 10,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  sourceItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 8,
+  },
+  sourceText: {
+    fontSize: 15,
+    color: Theme.surfaceBlue,
+    flex: 1,
+  },
+  pastTipsButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+    marginTop: 32,
+    paddingVertical: 12,
+    marginHorizontal: 20,
+    borderRadius: 12,
+    backgroundColor: Theme.surfaceGray,
+  },
+  pastTipsText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: Theme.surfaceBlue,
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#666',
+  },
+});
+
+export default TipDetailScreen;

--- a/unify-front-end/app/tip-detail.tsx
+++ b/unify-front-end/app/tip-detail.tsx
@@ -20,13 +20,34 @@ const formatDate = (dateString: string): string => {
   }
 };
 
+function isDailyTip(value: unknown): value is DailyTip {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    typeof v.persona === 'string' &&
+    typeof v.stage === 'string' &&
+    typeof v.date === 'string' &&
+    typeof v.category === 'string' &&
+    typeof v.title === 'string' &&
+    typeof v.description === 'string' &&
+    typeof v.tipText === 'string' &&
+    (v.sourceRefs === null || Array.isArray(v.sourceRefs))
+  );
+}
+
 const TipDetailScreen = () => {
   const { tip } = useLocalSearchParams<{ tip: string }>();
   const router = useRouter();
 
   let tipData: DailyTip | null = null;
   try {
-    tipData = tip ? JSON.parse(tip) : null;
+    const parsed = tip ? JSON.parse(tip) : null;
+    if (isDailyTip(parsed)) {
+      tipData = parsed;
+    } else if (parsed) {
+      console.error('Tip data failed validation:', Object.keys(parsed));
+    }
   } catch (error) {
     console.error('Error parsing tip data:', error);
   }

--- a/unify-front-end/components/HorizontalCarousel.tsx
+++ b/unify-front-end/components/HorizontalCarousel.tsx
@@ -20,6 +20,7 @@ interface HorizontalCarouselProps<T> {
   renderLoadingSkeleton: () => React.ReactNode;
   renderEmptyState: () => React.ReactNode;
   renderViewMore?: () => React.ReactNode;
+  renderPrefix?: () => React.ReactNode;
   onViewMore?: () => void;
   showViewMore?: boolean;
   style?: any;
@@ -38,6 +39,7 @@ export function HorizontalCarousel<T>({
   renderLoadingSkeleton,
   renderEmptyState,
   renderViewMore,
+  renderPrefix,
   onViewMore,
   showViewMore = true,
   style,
@@ -83,6 +85,7 @@ export function HorizontalCarousel<T>({
         {!isLoading && dataArray.length === 0 && (
           <View style={styles.emptyContainer}>{renderEmptyState()}</View>
         )}
+        {!isLoading && renderPrefix && <>{renderPrefix()}</>}
         {!isLoading && dataArray.length > 0 && (
           <>
             {displayItems.map((item, index) => {

--- a/unify-front-end/components/HorizontalCarousel.tsx
+++ b/unify-front-end/components/HorizontalCarousel.tsx
@@ -85,7 +85,7 @@ export function HorizontalCarousel<T>({
         {!isLoading && dataArray.length === 0 && (
           <View style={styles.emptyContainer}>{renderEmptyState()}</View>
         )}
-        {!isLoading && renderPrefix && <>{renderPrefix()}</>}
+        {renderPrefix && <>{renderPrefix()}</>}
         {!isLoading && dataArray.length > 0 && (
           <>
             {displayItems.map((item, index) => {

--- a/unify-front-end/components/news/NewsCarousel.tsx
+++ b/unify-front-end/components/news/NewsCarousel.tsx
@@ -10,10 +10,22 @@ import EmptyFeedMessage from '@/components/profile/EmptyFeedMessage';
 import { Theme } from '@/constants/Theme';
 import { HorizontalCarousel } from '@/components/HorizontalCarousel';
 import { NewsCardSkeletonLoader } from '@/components/news/NewsCardSkeletonLoader';
+import { DailyTipCard } from '@/components/tips/DailyTipCard';
+import { DailyTipCardSkeletonLoader } from '@/components/tips/DailyTipCardSkeletonLoader';
+import { useDailyTip } from '@/hooks/tips/useDailyTip';
+import { useCurrentUser } from '@/context/UserContext';
+import { useOnboardingProfile } from '@/hooks/onboarding/useOnboardingProfile';
 
 export const NewsCarousel = () => {
   const router = useRouter();
   const { data: news, isLoading } = useNews();
+
+  const { currentUser } = useCurrentUser();
+  const { data: profile } = useOnboardingProfile(currentUser?.id);
+  const { data: dailyTip, isLoading: isTipLoading } = useDailyTip(
+    profile?.persona ?? undefined,
+    profile?.stage ?? undefined
+  );
 
   const handleViewMore = () => {
     router.push('/news-tips' as any);
@@ -44,6 +56,22 @@ export const NewsCarousel = () => {
             onPress={() => handleNewsPress(item)}
           />
         )}
+        renderPrefix={() => {
+          if (isTipLoading) return <DailyTipCardSkeletonLoader />;
+          if (!dailyTip) return null;
+          return (
+            <DailyTipCard
+              tip={dailyTip}
+              maxWidth={332}
+              onPress={() =>
+                router.push({
+                  pathname: '/tip-detail' as any,
+                  params: { tip: JSON.stringify(dailyTip) },
+                })
+              }
+            />
+          );
+        }}
         renderLoadingSkeleton={() => <NewsCardSkeletonLoader />}
         renderEmptyState={() => (
           <EmptyFeedMessage

--- a/unify-front-end/components/tips/DailyTipCard.tsx
+++ b/unify-front-end/components/tips/DailyTipCard.tsx
@@ -27,12 +27,12 @@ interface DailyTipCardProps {
 
 export function DailyTipCard({ tip, maxWidth, onPress }: DailyTipCardProps) {
   const { trackTipViewed, trackTipTapped } = useAnalytics();
-  const hasTrackedView = useRef(false);
+  const lastTrackedTipId = useRef<string | null>(null);
 
   const config = CATEGORY_CONFIG[tip.category] || CATEGORY_CONFIG.general;
 
   useEffect(() => {
-    if (!hasTrackedView.current) {
+    if (lastTrackedTipId.current !== tip.id) {
       trackTipViewed({
         tip_id: tip.id,
         category: tip.category,
@@ -40,7 +40,7 @@ export function DailyTipCard({ tip, maxWidth, onPress }: DailyTipCardProps) {
         stage: tip.stage,
         date: tip.date,
       });
-      hasTrackedView.current = true;
+      lastTrackedTipId.current = tip.id;
     }
   }, [tip.id]);
 

--- a/unify-front-end/components/tips/DailyTipCard.tsx
+++ b/unify-front-end/components/tips/DailyTipCard.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useRef } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Feather } from '@expo/vector-icons';
+import { DailyTip } from '@/types/dailyTip';
+import { useAnalytics } from '@/utils/analytics';
+
+export const CATEGORY_CONFIG: Record<
+  string,
+  { gradient: [string, string]; icon: string; accent: string }
+> = {
+  documents: { gradient: ['#F0F4F8', '#E2E8F0'], icon: 'file-text', accent: '#64748B' },
+  finance: { gradient: ['#EFF6F0', '#E0EDE2'], icon: 'dollar-sign', accent: '#5B8A65' },
+  housing: { gradient: ['#F5F0EC', '#EBE3DA'], icon: 'home', accent: '#8B7355' },
+  employment: { gradient: ['#F2F0F5', '#E5E1ED'], icon: 'briefcase', accent: '#7B6B8A' },
+  healthcare: { gradient: ['#F5EFF2', '#EDE3E8'], icon: 'heart', accent: '#8A6575' },
+  immigration: { gradient: ['#EEF4F4', '#E0EAEB'], icon: 'globe', accent: '#5B7D82' },
+  settlement: { gradient: ['#F4F2EC', '#EAE6DA'], icon: 'users', accent: '#7D7455' },
+  general: { gradient: ['#F2F2F2', '#E8E8E8'], icon: 'star', accent: '#6B6B6B' },
+};
+
+interface DailyTipCardProps {
+  tip: DailyTip;
+  maxWidth?: number;
+  onPress?: () => void;
+}
+
+export function DailyTipCard({ tip, maxWidth, onPress }: DailyTipCardProps) {
+  const { trackTipViewed, trackTipTapped } = useAnalytics();
+  const hasTrackedView = useRef(false);
+
+  const config = CATEGORY_CONFIG[tip.category] || CATEGORY_CONFIG.general;
+
+  useEffect(() => {
+    if (!hasTrackedView.current) {
+      trackTipViewed({
+        tip_id: tip.id,
+        category: tip.category,
+        persona: tip.persona,
+        stage: tip.stage,
+        date: tip.date,
+      });
+      hasTrackedView.current = true;
+    }
+  }, [tip.id]);
+
+  const handlePress = () => {
+    trackTipTapped(tip.id, tip.category);
+    onPress?.();
+  };
+
+  return (
+    <TouchableOpacity
+      style={[styles.card, maxWidth !== undefined ? { width: maxWidth } : { width: '100%' }]}
+      onPress={handlePress}
+      activeOpacity={0.7}
+    >
+      <LinearGradient
+        colors={config.gradient}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.gradient}
+      >
+        <View style={styles.header}>
+          <View style={[styles.badge, { backgroundColor: config.accent + '14' }]}>
+            <Text style={[styles.badgeText, { color: config.accent }]}>Daily Tip</Text>
+          </View>
+          <View style={[styles.iconContainer, { backgroundColor: config.accent + '10' }]}>
+            <Feather
+              name={config.icon as any}
+              size={18}
+              color={config.accent}
+            />
+          </View>
+        </View>
+        <View style={styles.content}>
+          <Text style={styles.title} numberOfLines={2}>
+            {tip.title}
+          </Text>
+          <Text style={styles.tipText} numberOfLines={2} ellipsizeMode='tail'>
+            {tip.tipText}
+          </Text>
+        </View>
+      </LinearGradient>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    width: 332,
+    height: 132,
+    borderRadius: 16,
+    overflow: 'hidden',
+  },
+  gradient: {
+    flex: 1,
+    padding: 14,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 10,
+  },
+  badgeText: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.3,
+  },
+  iconContainer: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#1a1a1a',
+    marginBottom: 4,
+    lineHeight: 20,
+  },
+  tipText: {
+    fontSize: 13,
+    fontWeight: '400',
+    color: '#555',
+    lineHeight: 18,
+  },
+});

--- a/unify-front-end/components/tips/DailyTipCardSkeletonLoader.tsx
+++ b/unify-front-end/components/tips/DailyTipCardSkeletonLoader.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { SkeletonLoader } from '@/components/SkeletonLoader';
+
+export const DailyTipCardSkeletonLoader = () => {
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <SkeletonLoader
+          width={70}
+          height={20}
+          borderRadius={10}
+          style={styles.skeleton}
+        />
+        <SkeletonLoader
+          width={30}
+          height={30}
+          borderRadius={15}
+          style={styles.skeleton}
+        />
+      </View>
+      <View style={styles.content}>
+        <SkeletonLoader
+          width='80%'
+          height={18}
+          borderRadius={4}
+          style={styles.titleSkeleton}
+        />
+        <SkeletonLoader
+          width='95%'
+          height={14}
+          borderRadius={4}
+          style={styles.skeleton}
+        />
+        <SkeletonLoader
+          width='60%'
+          height={14}
+          borderRadius={4}
+          style={styles.skeleton}
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    width: 332,
+    height: 132,
+    borderRadius: 16,
+    backgroundColor: '#F5F5F5',
+    padding: 14,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  skeleton: {
+    backgroundColor: '#E0E0E0',
+  },
+  titleSkeleton: {
+    backgroundColor: '#E0E0E0',
+    marginBottom: 6,
+  },
+});

--- a/unify-front-end/hooks/tips/useDailyTip.ts
+++ b/unify-front-end/hooks/tips/useDailyTip.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { getDailyTip } from '@/services/tips/getDailyTip';
+
+function getTodayUTC(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+export const useDailyTip = (persona?: string, stage?: string) => {
+  return useQuery({
+    queryKey: ['dailyTip', persona, stage, getTodayUTC()],
+    queryFn: () => getDailyTip(persona!, stage!),
+    enabled: !!persona && !!stage,
+    staleTime: 1000 * 60 * 30, // 30 min — tip doesn't change intraday
+    gcTime: 1000 * 60 * 60, // 1 hour
+  });
+};

--- a/unify-front-end/hooks/tips/usePastTips.ts
+++ b/unify-front-end/hooks/tips/usePastTips.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { getPastTips } from '@/services/tips/getPastTips';
+
+export const usePastTips = (persona?: string, stage?: string) => {
+  return useQuery({
+    queryKey: ['pastTips', persona, stage],
+    queryFn: () => getPastTips(persona!, stage!),
+    enabled: !!persona && !!stage,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    gcTime: 1000 * 60 * 10, // 10 minutes
+  });
+};

--- a/unify-front-end/services/tips/getDailyTip.ts
+++ b/unify-front-end/services/tips/getDailyTip.ts
@@ -1,0 +1,54 @@
+import { supabase } from '@/lib/supabase';
+import { DailyTip } from '@/types/dailyTip';
+
+const HARDCODED_WELCOME_TIP: DailyTip = {
+  id: 'welcome-tip',
+  persona: 'other',
+  stage: '0',
+  date: new Date().toISOString().split('T')[0],
+  category: 'general',
+  title: 'Welcome to Canada!',
+  description: 'Start your journey with Unify',
+  tipText:
+    'Check back daily for personalized tips based on where you are in your newcomer journey. Complete your profile to get tips tailored to you!',
+  sourceRefs: null,
+};
+
+export const getDailyTip = async (
+  persona: string,
+  stage: string
+): Promise<DailyTip> => {
+  const today = new Date().toISOString().split('T')[0];
+  const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+
+  const { data, error } = await supabase
+    .from('daily_tips')
+    .select('*')
+    .eq('persona', persona)
+    .eq('stage', stage)
+    .gte('date', yesterday)
+    .order('date', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Error fetching daily tip:', error);
+    return HARDCODED_WELCOME_TIP;
+  }
+
+  if (!data) {
+    return HARDCODED_WELCOME_TIP;
+  }
+
+  return {
+    id: data.id,
+    persona: data.persona,
+    stage: data.stage,
+    date: data.date,
+    category: data.category,
+    title: data.title,
+    description: data.description,
+    tipText: data.tip_text,
+    sourceRefs: data.source_refs,
+  };
+};

--- a/unify-front-end/services/tips/getDailyTip.ts
+++ b/unify-front-end/services/tips/getDailyTip.ts
@@ -1,18 +1,20 @@
 import { supabase } from '@/lib/supabase';
 import { DailyTip } from '@/types/dailyTip';
 
-const HARDCODED_WELCOME_TIP: DailyTip = {
-  id: 'welcome-tip',
-  persona: 'other',
-  stage: '0',
-  date: new Date().toISOString().split('T')[0],
-  category: 'general',
-  title: 'Welcome to Canada!',
-  description: 'Start your journey with Unify',
-  tipText:
-    'Check back daily for personalized tips based on where you are in your newcomer journey. Complete your profile to get tips tailored to you!',
-  sourceRefs: null,
-};
+function buildWelcomeTip(persona: string, stage: string): DailyTip {
+  return {
+    id: `welcome-${persona}-${stage}`,
+    persona,
+    stage,
+    date: new Date().toISOString().split('T')[0],
+    category: 'general',
+    title: 'Welcome to Canada!',
+    description: 'Start your journey with Unify',
+    tipText:
+      'Check back daily for personalized tips based on where you are in your newcomer journey. Complete your profile to get tips tailored to you!',
+    sourceRefs: null,
+  };
+}
 
 export const getDailyTip = async (
   persona: string,
@@ -33,11 +35,11 @@ export const getDailyTip = async (
 
   if (error) {
     console.error('Error fetching daily tip:', error);
-    return HARDCODED_WELCOME_TIP;
+    return buildWelcomeTip(persona, stage);
   }
 
   if (!data) {
-    return HARDCODED_WELCOME_TIP;
+    return buildWelcomeTip(persona, stage);
   }
 
   return {

--- a/unify-front-end/services/tips/getPastTips.ts
+++ b/unify-front-end/services/tips/getPastTips.ts
@@ -1,0 +1,34 @@
+import { supabase } from '@/lib/supabase';
+import { DailyTip } from '@/types/dailyTip';
+
+export const getPastTips = async (
+  persona: string,
+  stage: string
+): Promise<DailyTip[]> => {
+  const { data, error } = await supabase
+    .from('daily_tips')
+    .select('*')
+    .eq('persona', persona)
+    .eq('stage', stage)
+    .order('date', { ascending: false })
+    .limit(30);
+
+  if (error) {
+    console.error('Error fetching past tips:', error);
+    return [];
+  }
+
+  return (
+    data?.map(tip => ({
+      id: tip.id,
+      persona: tip.persona,
+      stage: tip.stage,
+      date: tip.date,
+      category: tip.category,
+      title: tip.title,
+      description: tip.description,
+      tipText: tip.tip_text,
+      sourceRefs: tip.source_refs,
+    })) || []
+  );
+};

--- a/unify-front-end/supabase/functions/generate-daily-tips/index.ts
+++ b/unify-front-end/supabase/functions/generate-daily-tips/index.ts
@@ -1,0 +1,421 @@
+// @ts-nocheck
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { fetchWithRetry } from '../_shared/fetchWithRetry.ts';
+import { captureAiGeneration, computeGeminiCost } from '../_shared/posthogCapture.ts';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const PERSONAS = ['international_student', 'skilled_worker', 'refugee', 'other'] as const;
+const STAGES = ['0', '1', '2', '3', '4'] as const;
+const BATCH_SIZE = 5;
+
+const EMBEDDING_MODEL =
+  Deno.env.get('OPENAI_EMBEDDING_MODEL') || 'text-embedding-3-small';
+
+const STAGE_DESCRIPTIONS: Record<string, string> = {
+  '0': 'pre-arrival or just arrived (0-1 months)',
+  '1': 'settling in (1-3 months)',
+  '2': 'building foundations (3-6 months)',
+  '3': 'establishing roots (6-12 months)',
+  '4': 'well-established (12+ months)',
+};
+
+const PERSONA_DESCRIPTIONS: Record<string, string> = {
+  international_student: 'international student studying in Canada',
+  skilled_worker: 'skilled worker who immigrated to Canada',
+  refugee: 'refugee or protected person in Canada',
+  other: 'newcomer to Canada',
+};
+
+// ============================================================================
+// TIP GENERATION
+// ============================================================================
+
+interface GeneratedTip {
+  category: string;
+  title: string;
+  description: string;
+  tip_text: string;
+}
+
+const VALID_CATEGORIES = [
+  'documents', 'finance', 'housing', 'employment',
+  'healthcare', 'immigration', 'settlement', 'general',
+];
+
+function buildTopicQuery(persona: string, stage: string): string {
+  const personaDesc = PERSONA_DESCRIPTIONS[persona] || 'newcomer to Canada';
+  const stageDesc = STAGE_DESCRIPTIONS[stage] || 'newcomer';
+  return `practical tips for ${personaDesc} who is ${stageDesc}`;
+}
+
+function buildGeminiPrompt(
+  persona: string,
+  stage: string,
+  date: string,
+  kbContext: string
+): string {
+  const personaDesc = PERSONA_DESCRIPTIONS[persona] || 'newcomer to Canada';
+  const stageDesc = STAGE_DESCRIPTIONS[stage] || 'newcomer';
+
+  return `You are generating a daily tip for newcomers to Canada.
+
+USER PROFILE:
+- Persona: ${personaDesc}
+- Stage: ${stageDesc}
+- Time context: ${date}
+
+KNOWLEDGE BASE CONTEXT:
+${kbContext || 'No specific knowledge base context available. Use your general knowledge about Canadian newcomer resources.'}
+
+Generate a single, specific, actionable tip. Respond ONLY with valid JSON (no markdown, no code fences):
+{
+  "category": "documents|finance|housing|employment|healthcare|immigration|settlement|general",
+  "title": "short title (max 60 chars)",
+  "description": "one-line summary (max 80 chars)",
+  "tip_text": "the full tip, specific and actionable (max 200 chars)"
+}
+
+RULES:
+- Be specific to this persona and stage
+- Reference real Canadian programs, services, or resources when possible
+- No legal advice — use "generally" or "typically"
+- No eligibility determinations
+- Keep it actionable — tell them what to DO, not just what to know
+- Vary the category day-to-day — do not always pick the same topic`;
+}
+
+function parseGeminiTipResponse(rawText: string): GeneratedTip | null {
+  try {
+    // Strip markdown code fences if present
+    let cleaned = rawText.trim();
+    if (cleaned.startsWith('```')) {
+      cleaned = cleaned.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '');
+    }
+
+    const parsed = JSON.parse(cleaned);
+
+    if (!parsed.category || !parsed.title || !parsed.description || !parsed.tip_text) {
+      console.error('Missing required fields in tip response');
+      return null;
+    }
+
+    // Validate category
+    const category = VALID_CATEGORIES.includes(parsed.category)
+      ? parsed.category
+      : 'general';
+
+    return {
+      category,
+      title: String(parsed.title).slice(0, 60),
+      description: String(parsed.description).slice(0, 80),
+      tip_text: String(parsed.tip_text).slice(0, 200),
+    };
+  } catch (error) {
+    console.error('Failed to parse tip JSON:', error, 'Raw:', rawText.slice(0, 300));
+    return null;
+  }
+}
+
+async function generateEmbedding(
+  text: string,
+  openaiApiKey: string
+): Promise<number[] | null> {
+  try {
+    const response = await fetchWithRetry(
+      'https://api.openai.com/v1/embeddings',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${openaiApiKey}`,
+        },
+        body: JSON.stringify({
+          model: EMBEDDING_MODEL,
+          input: text,
+        }),
+      },
+      { timeoutMs: 15000, retries: 2, retryDelayMs: 400 }
+    );
+
+    if (!response.ok) {
+      console.error('OpenAI embedding error:', response.statusText);
+      return null;
+    }
+
+    const data = await response.json();
+    return data.data[0].embedding;
+  } catch (error) {
+    console.error('Embedding generation failed:', error);
+    return null;
+  }
+}
+
+async function searchKnowledgeBase(
+  supabase: ReturnType<typeof createClient>,
+  embedding: number[]
+): Promise<string> {
+  try {
+    const { data: chunks, error } = await supabase.rpc('match_chunks', {
+      query_embedding: embedding,
+      match_threshold: 0.3,
+      match_count: 5,
+    });
+
+    if (error || !chunks || chunks.length === 0) {
+      return '';
+    }
+
+    return chunks
+      .map((chunk: any) => chunk.content)
+      .join('\n\n')
+      .slice(0, 3000); // Cap context size
+  } catch (error) {
+    console.error('KB search failed:', error);
+    return '';
+  }
+}
+
+async function callGemini(
+  prompt: string,
+  geminiApiKey: string,
+  model: string
+): Promise<{ text: string; usage: any } | null> {
+  try {
+    const response = await fetchWithRetry(
+      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${geminiApiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contents: [
+            {
+              role: 'user',
+              parts: [{ text: prompt }],
+            },
+          ],
+          generationConfig: {
+            maxOutputTokens: 300,
+            temperature: 0.8,
+          },
+        }),
+      },
+      { timeoutMs: 20000, retries: 2, retryDelayMs: 500 }
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('Gemini API error:', response.status, errorText);
+      return null;
+    }
+
+    const data = await response.json();
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+    if (!text) return null;
+
+    return { text, usage: data.usageMetadata };
+  } catch (error) {
+    console.error('Gemini call failed:', error);
+    return null;
+  }
+}
+
+async function generateTipForCohort(
+  supabase: ReturnType<typeof createClient>,
+  persona: string,
+  stage: string,
+  date: string,
+  openaiApiKey: string | null,
+  geminiApiKey: string,
+  model: string
+): Promise<{ success: boolean; persona: string; stage: string }> {
+  const cohortKey = `${persona}/${stage}`;
+
+  // Step 1: Build topic query and get KB context
+  let kbContext = '';
+  if (openaiApiKey) {
+    const topicQuery = buildTopicQuery(persona, stage);
+    const embedding = await generateEmbedding(topicQuery, openaiApiKey);
+    if (embedding) {
+      kbContext = await searchKnowledgeBase(supabase, embedding);
+    }
+  }
+
+  // Step 2: Generate tip via Gemini
+  const prompt = buildGeminiPrompt(persona, stage, date, kbContext);
+  const geminiResult = await callGemini(prompt, geminiApiKey, model);
+
+  if (!geminiResult) {
+    console.error(`[${cohortKey}] Gemini call failed`);
+    return { success: false, persona, stage };
+  }
+
+  // Step 3: Parse response
+  let tip = parseGeminiTipResponse(geminiResult.text);
+
+  // Retry once on parse failure
+  if (!tip) {
+    console.warn(`[${cohortKey}] Parse failed, retrying once`);
+    const retryResult = await callGemini(prompt, geminiApiKey, model);
+    if (retryResult) {
+      tip = parseGeminiTipResponse(retryResult.text);
+    }
+  }
+
+  if (!tip) {
+    console.error(`[${cohortKey}] Failed to generate valid tip after retry`);
+    return { success: false, persona, stage };
+  }
+
+  // Step 4: Upsert into daily_tips
+  const { error: upsertError } = await supabase
+    .from('daily_tips')
+    .upsert(
+      {
+        persona,
+        stage,
+        date,
+        category: tip.category,
+        title: tip.title,
+        description: tip.description,
+        tip_text: tip.tip_text,
+        source_refs: kbContext ? [{ source: 'knowledge_base' }] : null,
+      },
+      { onConflict: 'persona,stage,date' }
+    );
+
+  if (upsertError) {
+    console.error(`[${cohortKey}] DB upsert error:`, upsertError);
+    return { success: false, persona, stage };
+  }
+
+  // Step 5: PostHog tracking
+  if (geminiResult.usage) {
+    const cost = computeGeminiCost(
+      geminiResult.usage.promptTokenCount || 0,
+      geminiResult.usage.candidatesTokenCount || 0,
+      model
+    );
+    captureAiGeneration(`system:daily-tips:${cohortKey}`, {
+      $ai_model: model,
+      $ai_provider: 'google',
+      $ai_input_tokens: geminiResult.usage.promptTokenCount || 0,
+      $ai_output_tokens: geminiResult.usage.candidatesTokenCount || 0,
+      $ai_total_tokens: geminiResult.usage.totalTokenCount || 0,
+      $ai_input_cost_usd: cost.inputCost,
+      $ai_output_cost_usd: cost.outputCost,
+      $ai_total_cost_usd: cost.totalCost,
+      feature: 'daily_tips',
+      persona,
+      stage,
+      category: tip.category,
+    });
+  }
+
+  console.log(`[${cohortKey}] Generated tip: "${tip.title}" (${tip.category})`);
+  return { success: true, persona, stage };
+}
+
+// ============================================================================
+// MAIN HANDLER
+// ============================================================================
+
+Deno.serve(async (req: Request) => {
+  const startTime = performance.now();
+
+  try {
+    // Auth: verify service role key
+    const authHeader = req.headers.get('Authorization');
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+
+    if (!authHeader || !authHeader.includes(serviceRoleKey)) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+    const geminiApiKey = Deno.env.get('GEMINI_API_KEY');
+    if (!geminiApiKey) {
+      return new Response(JSON.stringify({ error: 'GEMINI_API_KEY not configured' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const openaiApiKey = Deno.env.get('OPENAI_API_KEY') || null;
+    if (!openaiApiKey) {
+      console.warn('OPENAI_API_KEY not set — generating tips without RAG grounding');
+    }
+
+    const model = Deno.env.get('GEMINI_MODEL') || 'gemini-2.5-flash';
+    const today = new Date().toISOString().split('T')[0]; // UTC date
+
+    // Build cohort matrix
+    const cohorts: Array<{ persona: string; stage: string }> = [];
+    for (const persona of PERSONAS) {
+      for (const stage of STAGES) {
+        cohorts.push({ persona, stage });
+      }
+    }
+
+    console.log(`Generating ${cohorts.length} tips for date ${today}`);
+
+    // Process in batches of BATCH_SIZE
+    let successCount = 0;
+    let failureCount = 0;
+
+    for (let i = 0; i < cohorts.length; i += BATCH_SIZE) {
+      const batch = cohorts.slice(i, i + BATCH_SIZE);
+      const results = await Promise.all(
+        batch.map(({ persona, stage }) =>
+          generateTipForCohort(
+            supabase,
+            persona,
+            stage,
+            today,
+            openaiApiKey,
+            geminiApiKey,
+            model
+          )
+        )
+      );
+
+      for (const result of results) {
+        if (result.success) {
+          successCount++;
+        } else {
+          failureCount++;
+        }
+      }
+    }
+
+    const totalTime = Math.round(performance.now() - startTime);
+    const summary = {
+      date: today,
+      total: cohorts.length,
+      success: successCount,
+      failed: failureCount,
+      duration_ms: totalTime,
+    };
+
+    console.log('Generation complete:', summary);
+
+    return new Response(JSON.stringify(summary), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('Fatal error in generate-daily-tips:', error);
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : 'Unknown error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/unify-front-end/supabase/functions/generate-daily-tips/index.ts
+++ b/unify-front-end/supabase/functions/generate-daily-tips/index.ts
@@ -154,10 +154,20 @@ async function generateEmbedding(
   }
 }
 
+interface SourceRef {
+  document_title: string;
+  url: string;
+}
+
+interface KBSearchResult {
+  context: string;
+  sourceRefs: SourceRef[] | null;
+}
+
 async function searchKnowledgeBase(
   supabase: ReturnType<typeof createClient>,
   embedding: number[]
-): Promise<string> {
+): Promise<KBSearchResult> {
   try {
     const { data: chunks, error } = await supabase.rpc('match_chunks', {
       query_embedding: embedding,
@@ -166,16 +176,34 @@ async function searchKnowledgeBase(
     });
 
     if (error || !chunks || chunks.length === 0) {
-      return '';
+      return { context: '', sourceRefs: null };
     }
 
-    return chunks
-      .map((chunk: any) => chunk.content)
+    const context = chunks
+      .map((chunk: any) => chunk.chunk_text)
       .join('\n\n')
       .slice(0, 3000); // Cap context size
+
+    // Extract unique source references from chunk metadata
+    const seenUrls = new Set<string>();
+    const sourceRefs: SourceRef[] = [];
+    for (const chunk of chunks) {
+      const doc = chunk.knowledge_documents || {};
+      const title = doc.title;
+      const url = doc.source_url;
+      if (title && url && !seenUrls.has(url)) {
+        seenUrls.add(url);
+        sourceRefs.push({ document_title: title, url });
+      }
+    }
+
+    return {
+      context,
+      sourceRefs: sourceRefs.length > 0 ? sourceRefs : null,
+    };
   } catch (error) {
     console.error('KB search failed:', error);
-    return '';
+    return { context: '', sourceRefs: null };
   }
 }
 
@@ -236,11 +264,14 @@ async function generateTipForCohort(
 
   // Step 1: Build topic query and get KB context
   let kbContext = '';
+  let sourceRefs: SourceRef[] | null = null;
   if (openaiApiKey) {
     const topicQuery = buildTopicQuery(persona, stage);
     const embedding = await generateEmbedding(topicQuery, openaiApiKey);
     if (embedding) {
-      kbContext = await searchKnowledgeBase(supabase, embedding);
+      const kbResult = await searchKnowledgeBase(supabase, embedding);
+      kbContext = kbResult.context;
+      sourceRefs = kbResult.sourceRefs;
     }
   }
 
@@ -282,7 +313,7 @@ async function generateTipForCohort(
         title: tip.title,
         description: tip.description,
         tip_text: tip.tip_text,
-        source_refs: kbContext ? [{ source: 'knowledge_base' }] : null,
+        source_refs: sourceRefs,
       },
       { onConflict: 'persona,stage,date' }
     );

--- a/unify-front-end/supabase/migrations/20260324_create_daily_tips.sql
+++ b/unify-front-end/supabase/migrations/20260324_create_daily_tips.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- Daily tips table
+-- Stores AI-generated daily tips for each persona×stage cohort (4×5 = 20/day)
+-- ============================================================================
+
+CREATE TABLE daily_tips (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  persona TEXT NOT NULL,
+  stage TEXT NOT NULL,
+  date DATE NOT NULL DEFAULT CURRENT_DATE,
+  category TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+  tip_text TEXT NOT NULL,
+  source_refs JSONB,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(persona, stage, date)
+);
+
+-- RLS: authenticated users can read all tips (public content)
+ALTER TABLE daily_tips ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Authenticated users can read tips"
+  ON daily_tips FOR SELECT TO authenticated USING (true);
+
+-- Index for client queries (persona + stage + date DESC for fallback lookup)
+CREATE INDEX idx_daily_tips_lookup ON daily_tips(persona, stage, date DESC);

--- a/unify-front-end/supabase/migrations/20260324_z_daily_tips_schedule.sql
+++ b/unify-front-end/supabase/migrations/20260324_z_daily_tips_schedule.sql
@@ -1,0 +1,69 @@
+-- ============================================================================
+-- Daily tips cron schedule
+-- Runs daily at 6 AM UTC to generate personalized tips for each cohort
+-- Pattern: vault-based wrapper function (same as learn reminders)
+-- ============================================================================
+
+create or replace function public.trigger_generate_daily_tips()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  _supabase_url text;
+  _service_key text;
+begin
+  _supabase_url := current_setting('app.settings.supabase_url', true);
+  if _supabase_url is null or _supabase_url = '' then
+    _supabase_url := (
+      select decrypted_secret from vault.decrypted_secrets
+      where name = 'supabase_url'
+      limit 1
+    );
+  end if;
+
+  _service_key := (
+    select decrypted_secret from vault.decrypted_secrets
+    where name = 'service_role_key'
+    limit 1
+  );
+
+  if _supabase_url is null or _service_key is null then
+    raise warning 'trigger_generate_daily_tips: missing supabase_url or service_role_key in vault';
+    return;
+  end if;
+
+  perform net.http_post(
+    url := _supabase_url || '/functions/v1/generate-daily-tips',
+    headers := json_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || _service_key
+    )::jsonb,
+    body := '{}'::jsonb,
+    timeout_milliseconds := 120000
+  );
+end;
+$$;
+
+revoke execute on function public.trigger_generate_daily_tips() from public, anon, authenticated;
+grant execute on function public.trigger_generate_daily_tips() to service_role;
+
+-- Schedule: 6 AM UTC daily (idempotent — unschedule first)
+do $$
+declare
+  _job_id bigint;
+begin
+  for _job_id in
+    select jobid from cron.job where jobname = 'generate-daily-tips'
+  loop
+    perform cron.unschedule(_job_id);
+  end loop;
+
+  perform cron.schedule(
+    'generate-daily-tips',
+    '0 6 * * *',
+    'select public.trigger_generate_daily_tips()'
+  );
+end;
+$$;

--- a/unify-front-end/supabase/migrations/20260324_z_daily_tips_schedule.sql
+++ b/unify-front-end/supabase/migrations/20260324_z_daily_tips_schedule.sql
@@ -41,7 +41,7 @@ begin
       'Authorization', 'Bearer ' || _service_key
     )::jsonb,
     body := '{}'::jsonb,
-    timeout_milliseconds := 120000
+    timeout_milliseconds := 300000
   );
 end;
 $$;

--- a/unify-front-end/types/dailyTip.ts
+++ b/unify-front-end/types/dailyTip.ts
@@ -1,0 +1,11 @@
+export interface DailyTip {
+  id: string;
+  persona: string;
+  stage: string;
+  date: string;
+  category: string;
+  title: string;
+  description: string;
+  tipText: string;
+  sourceRefs: { document_title: string; url: string }[] | null;
+}

--- a/unify-front-end/utils/analytics.ts
+++ b/unify-front-end/utils/analytics.ts
@@ -89,6 +89,10 @@ export const AnalyticsEvents = {
 
   // AI Companion (extended)
   COMPANION_RESPONSE_RECEIVED: 'companion_response_received',
+
+  // Daily Tips
+  TIP_VIEWED: 'tip_viewed',
+  TIP_TAPPED: 'tip_tapped',
 } as const;
 
 export type AnalyticsEventName =
@@ -174,6 +178,14 @@ export interface CompanionResponseProperties {
   total_tokens?: number;
   estimated_cost_usd?: number;
   response_time_ms?: number;
+}
+
+export interface TipViewedProperties {
+  tip_id: string;
+  category: string;
+  persona: string;
+  stage: string;
+  date: string;
 }
 
 // Hook for analytics tracking
@@ -517,6 +529,17 @@ export function useAnalytics() {
           AnalyticsEvents.COMPANION_RESPONSE_RECEIVED,
           { ...properties }
         );
+      },
+
+      // Daily Tips
+      trackTipViewed: (properties: TipViewedProperties) => {
+        posthog?.capture(AnalyticsEvents.TIP_VIEWED, { ...properties });
+      },
+      trackTipTapped: (tipId: string, category: string) => {
+        posthog?.capture(AnalyticsEvents.TIP_TAPPED, {
+          tip_id: tipId,
+          category,
+        });
       },
 
       // Generic event capture


### PR DESCRIPTION
## Summary
- Adds AI-generated personalized daily tips as the first card in the News & Tips carousel on the Community tab
- Tips are generated daily via Gemini + RAG pipeline, batched per persona×stage cohort (20 tips/day), stored in `daily_tips` Supabase table with pg_cron scheduling
- Tip card shows category-based gradient, icon, badge, title, and truncated tip text
- Tapping the card opens a new **tip detail screen** with full content, formatted date, source references, and a link to past tips
- Past tips screen shows tip history as a scrollable list, each card navigable to its detail view
- Fallback chain: today's tip → yesterday's tip → hardcoded welcome tip
- PostHog analytics: `tip_viewed` on mount, `tip_tapped` on press

## Files added
- `app/tip-detail.tsx` — full tip detail screen
- `app/past-tips.tsx` — past tips history screen
- `components/tips/DailyTipCard.tsx` — tip card with category gradients
- `components/tips/DailyTipCardSkeletonLoader.tsx` — loading skeleton
- `hooks/tips/useDailyTip.ts`, `usePastTips.ts` — React Query hooks
- `services/tips/getDailyTip.ts`, `getPastTips.ts` — Supabase service layer
- `types/dailyTip.ts` — DailyTip type definition
- `supabase/functions/generate-daily-tips/index.ts` — edge function (Gemini + RAG)
- `supabase/migrations/20260324_create_daily_tips.sql` — table, RLS, indexes
- `supabase/migrations/20260324_z_daily_tips_schedule.sql` — pg_cron schedule

## Files modified
- `app/_layout.tsx` — register `past-tips` and `tip-detail` screens
- `components/HorizontalCarousel.tsx` — add `renderPrefix` prop
- `components/news/NewsCarousel.tsx` — inject tip card as first carousel item
- `utils/analytics.ts` — add tip tracking events

## Test plan
- [ ] Open Community tab → verify daily tip card appears as first item in News & Tips carousel
- [ ] Tap tip card → opens tip detail screen with full content, category header, date, source refs
- [ ] Back button on tip detail → returns to Community tab
- [ ] Tap "See past tips" on detail screen → navigates to past tips list
- [ ] Tap any card on past tips screen → opens tip detail for that tip
- [ ] Verify fallback: if no tips in DB, hardcoded welcome tip appears
- [ ] Verify skeleton loader shows while tip is loading
- [ ] Verify PostHog events: `tip_viewed`, `tip_tapped`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily Tips feature with personalized recommendations surfaced as a prefix card in news carousels.
  * Past Tips screen for browsing archived tips and Tip Detail screen for full content, sources, and navigation between them.
  * Tip cards and skeleton loaders for inline and loading states.

* **Chores**
  * Backend & database support for storing/generated daily tips and a scheduler to create them.
  * Analytics events added for tip views and taps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->