### PR TITLE
feat: iOS App Store review prompt during onboarding

### DIFF
--- a/unify-front-end/components/onboarding/OnboardingQuiz.tsx
+++ b/unify-front-end/components/onboarding/OnboardingQuiz.tsx
@@ -31,6 +31,7 @@ import {
 } from '@/types/onboardingProfile';
 import { useAnalytics } from '@/utils/analytics';
 import { registerForPushNotifications } from '@/services/push/pushNotifications';
+import { requestStoreReview } from '@/utils/storeReview';
 
 interface OnboardingQuizProps {
   onComplete: () => void;
@@ -203,6 +204,11 @@ export default function OnboardingQuiz({
       registerForPushNotifications().catch(err => {
         console.error('Push registration from onboarding failed:', err);
       });
+    }
+
+    // Request iOS App Store review after Outcomes step (peak positive sentiment)
+    if (currentStep === 10 && !isRedo) {
+      requestStoreReview();
     }
 
     if (currentStep < TOTAL_STEPS) {

--- a/unify-front-end/package-lock.json
+++ b/unify-front-end/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "unify-front-end",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.908.0",
@@ -42,6 +42,7 @@
         "expo-secure-store": "~14.2.4",
         "expo-splash-screen": "~0.30.10",
         "expo-status-bar": "~2.2.3",
+        "expo-store-review": "~8.1.5",
         "expo-system-ui": "~5.0.11",
         "expo-updates": "~0.28.18",
         "generate-random-username": "^2.0.1",
@@ -12279,6 +12280,16 @@
       },
       "peerDependencies": {
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-store-review": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/expo-store-review/-/expo-store-review-8.1.5.tgz",
+      "integrity": "sha512-PMNMIt6UrdMYyRzCCbmCmbIkwSgIXhGNQHsgmOgq9FgtYLW5Oo2FD3zwB0KU2u/MpTTt/XyuuADuFvxE+Vh9uw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },

--- a/unify-front-end/package.json
+++ b/unify-front-end/package.json
@@ -52,6 +52,7 @@
     "expo-secure-store": "~14.2.4",
     "expo-splash-screen": "~0.30.10",
     "expo-status-bar": "~2.2.3",
+    "expo-store-review": "~8.1.5",
     "expo-system-ui": "~5.0.11",
     "expo-updates": "~0.28.18",
     "generate-random-username": "^2.0.1",

--- a/unify-front-end/utils/storeReview.ts
+++ b/unify-front-end/utils/storeReview.ts
@@ -1,0 +1,22 @@
+import { Platform } from 'react-native';
+
+/**
+ * Request the native iOS App Store review prompt.
+ * Dynamically imports expo-store-review to avoid crashing
+ * when the native module isn't available (e.g. Expo Go).
+ * Fire-and-forget — never blocks UI or throws.
+ */
+export async function requestStoreReview(): Promise<void> {
+  if (Platform.OS !== 'ios') return;
+
+  try {
+    const StoreReview = await import('expo-store-review');
+
+    const available = await StoreReview.isAvailableAsync();
+    if (!available) return;
+
+    await StoreReview.requestReview();
+  } catch {
+    // Non-critical — silently ignore if native module unavailable
+  }
+}


### PR DESCRIPTION
## Summary

- Adds native iOS App Store review prompt (`expo-store-review`) triggered after the Outcomes step (step 10 → 11) during first-time onboarding
- Uses dynamic import to avoid crashes in Expo Go where the native module isn't available
- Skips the prompt on redo-onboarding flows (`isRedo`) to avoid wasting one of Apple's 3 annual prompt slots

## Details

- **Library:** `expo-store-review` (first-party Expo, actively maintained, works with SDK 53)
- **Placement:** After the "Here's what you can achieve in 3 months" Outcomes screen — peak positive sentiment moment, user has invested time answering 8+ questions
- **Platform:** iOS only — Android is out of scope per ticket
- **Safety:** Fire-and-forget, wrapped in try/catch, never blocks UI. If the native module isn't available or Apple's OS suppresses the prompt, nothing happens

## Files changed

- `utils/storeReview.ts` — new utility with iOS guard, availability check, and dynamic import
- `components/onboarding/OnboardingQuiz.tsx` — triggers review at step 10→11 transition (first-time only)
- `package.json` / `package-lock.json` — added `expo-store-review`

## Test plan

- [ ] Rebuild dev client (`npx expo run:ios`) to include the native module
- [ ] Complete first-time onboarding — verify native review dialog appears after Outcomes step
- [ ] Redo onboarding from profile settings — verify prompt does NOT appear
- [ ] Verify onboarding flow is not blocked/interrupted if prompt is suppressed

ClickUp: https://app.clickup.com/t/86agn32e8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* iOS users may now receive a prompt to review the app on the App Store upon completing the onboarding quiz.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->