### PR TITLE
Fix: iOS push notifications not working

### DIFF
--- a/unify-front-end/services/posts/createComment.ts
+++ b/unify-front-end/services/posts/createComment.ts
@@ -36,10 +36,12 @@ export const createComment = async (
   }
 
   if (data) {
-    createCommentNotification(postId, data.id).catch(() => {});
+    createCommentNotification(postId, data.id).catch(err =>
+      console.error('[Notification] comment failed:', err)
+    );
     if (parentCommentId) {
       createCommentReplyNotification(postId, data.id, parentCommentId).catch(
-        () => {}
+        err => console.error('[Notification] comment reply failed:', err)
       );
     }
   }

--- a/unify-front-end/services/posts/likePost.ts
+++ b/unify-front-end/services/posts/likePost.ts
@@ -21,7 +21,9 @@ export const likePost = async (postId: number): Promise<LikePostResponse> => {
     });
 
     // Notify post author (fire-and-forget)
-    createPostLikeNotification(postId).catch(() => {});
+    createPostLikeNotification(postId).catch(err =>
+      console.error('[Notification] like failed:', err)
+    );
 
     // Get updated like count from posts table (trigger will have updated it)
     const { data: postData } = await supabase

--- a/unify-front-end/services/push/pushNotifications.ts
+++ b/unify-front-end/services/push/pushNotifications.ts
@@ -20,7 +20,7 @@ Notifications.setNotificationHandler({
 export async function registerForPushNotifications(): Promise<string | null> {
   // Push notifications only work on physical devices
   if (!Device.isDevice) {
-    console.log('Push notifications require a physical device');
+    console.warn('[Push] Skipped: not a physical device');
     return null;
   }
 
@@ -35,7 +35,7 @@ export async function registerForPushNotifications(): Promise<string | null> {
   }
 
   if (finalStatus !== 'granted') {
-    console.log('Push notification permission not granted');
+    console.warn('[Push] Skipped: permission not granted, status:', finalStatus);
     return null;
   }
 
@@ -65,34 +65,70 @@ export async function registerForPushNotifications(): Promise<string | null> {
     });
 
     const token = tokenData.data;
+    console.log('[Push] Token obtained:', token);
 
     // Store token in Supabase
     const {
       data: { user },
     } = await supabase.auth.getUser();
-    if (user && token) {
-      const { error } = await supabase.from('push_tokens').upsert(
-        {
-          user_id: user.id,
-          token,
-          platform: Platform.OS,
-          updated_at: new Date().toISOString(),
-        },
-        {
-          onConflict: 'token',
-        }
-      );
 
+    if (!user) {
+      console.warn('[Push] No authenticated user, skipping token storage');
+      return token;
+    }
+
+    if (!token) {
+      console.warn('[Push] Token is empty, skipping storage');
+      return null;
+    }
+
+    // First try to update existing token for this user on this platform
+    const { data: existing } = await supabase
+      .from('push_tokens')
+      .select('id, token')
+      .eq('user_id', user.id)
+      .eq('platform', Platform.OS)
+      .maybeSingle();
+
+    if (existing && existing.token === token) {
+      // Token unchanged, just update timestamp
+      await supabase
+        .from('push_tokens')
+        .update({ updated_at: new Date().toISOString() })
+        .eq('id', existing.id);
+      console.log('[Push] Token unchanged, updated timestamp');
+    } else if (existing) {
+      // Token changed — delete old and insert new
+      await supabase.from('push_tokens').delete().eq('id', existing.id);
+      const { error } = await supabase.from('push_tokens').insert({
+        user_id: user.id,
+        token,
+        platform: Platform.OS,
+        updated_at: new Date().toISOString(),
+      });
       if (error) {
-        console.error('Failed to store push token', error);
+        console.error('[Push] Failed to store updated token:', error.message, error.code, error.details);
       } else {
-        console.log('Push token registered successfully');
+        console.log('[Push] Token updated successfully');
+      }
+    } else {
+      // No existing token — insert new
+      const { error } = await supabase.from('push_tokens').insert({
+        user_id: user.id,
+        token,
+        platform: Platform.OS,
+        updated_at: new Date().toISOString(),
+      });
+      if (error) {
+        console.error('[Push] Failed to store new token:', error.message, error.code, error.details);
+      } else {
+        console.log('[Push] Token registered successfully');
       }
     }
 
     return token;
   } catch (error) {
-    console.error('Failed to get push token', error);
+    console.error('[Push] Registration failed:', error);
     return null;
   }
 }

--- a/unify-front-end/services/users/followUser.ts
+++ b/unify-front-end/services/users/followUser.ts
@@ -28,7 +28,9 @@ export const followUser = async ({
         throw new Error(`Failed to follow user: ${error.message}`);
       }
 
-      createFollowNotification(targetUserId).catch(() => {});
+      createFollowNotification(targetUserId).catch(err =>
+        console.error('[Notification] follow failed:', err)
+      );
     } else {
       // Unfollow the user
       const { error } = await supabase

--- a/unify-front-end/supabase/functions/matchmake-circles/index.ts
+++ b/unify-front-end/supabase/functions/matchmake-circles/index.ts
@@ -1186,12 +1186,17 @@ async function sendPushNotifications(
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
+      const pushHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      };
+      const expoToken = Deno.env.get('EXPO_ACCESS_TOKEN');
+      if (expoToken) {
+        pushHeaders['Authorization'] = `Bearer ${expoToken}`;
+      }
       const response = await fetch('https://exp.host/--/api/v2/push/send', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-        },
+        headers: pushHeaders,
         body: JSON.stringify(batch),
         signal: controller.signal,
       });

--- a/unify-front-end/supabase/functions/send-learn-reminders/index.ts
+++ b/unify-front-end/supabase/functions/send-learn-reminders/index.ts
@@ -4,6 +4,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL');
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 const LEARN_REMINDERS_API_KEY = Deno.env.get('LEARN_REMINDERS_API_KEY');
+const EXPO_ACCESS_TOKEN = Deno.env.get('EXPO_ACCESS_TOKEN');
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send';
@@ -73,12 +74,16 @@ async function sendExpoPush(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      };
+      if (EXPO_ACCESS_TOKEN) {
+        headers['Authorization'] = `Bearer ${EXPO_ACCESS_TOKEN}`;
+      }
       const res = await fetch(EXPO_PUSH_URL, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-        },
+        headers,
         body: JSON.stringify(batch),
         signal: controller.signal,
       });

--- a/unify-front-end/supabase/functions/send-social-push/index.ts
+++ b/unify-front-end/supabase/functions/send-social-push/index.ts
@@ -6,6 +6,7 @@ import {
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL');
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+const EXPO_ACCESS_TOKEN = Deno.env.get('EXPO_ACCESS_TOKEN');
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
@@ -89,12 +90,16 @@ async function sendExpoPushToUsers(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      };
+      if (EXPO_ACCESS_TOKEN) {
+        headers['Authorization'] = `Bearer ${EXPO_ACCESS_TOKEN}`;
+      }
       const res = await fetch(EXPO_PUSH_URL, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-        },
+        headers,
         body: JSON.stringify(batch),
         signal: controller.signal,
       });


### PR DESCRIPTION
## Summary

- **Fixed push token registration** — replaced `upsert` with `onConflict: 'token'` (which silently failed due to RLS conflicts) with an explicit check-then-insert/update flow
- **Added Expo access token** (`EXPO_ACCESS_TOKEN`) to all three push-sending edge functions: `send-social-push`, `send-learn-reminders`, `matchmake-circles`
- **Replaced silent `.catch(() => {})` error swallowing** in notification creation call sites with actual error logging

## Context

Investigation found 0/236 notifications ever delivered, and the developer's own account had no push token stored despite active use. The `upsert` with `onConflict: 'token'` was the likely root cause for token storage failures — RLS policies blocked updates when device tokens were reassigned between users.

Edge functions are already deployed and the Expo Push API has been verified working (ok tickets + Apple APNs delivery confirmed).

## Test plan

- [ ] Build app on physical iOS device
- [ ] Verify `[Push] Token registered successfully` appears in console logs
- [ ] Verify push token appears in `push_tokens` table for the test user
- [ ] Trigger a social action (like/comment/follow) and confirm push notification arrives
- [ ] Check edge function logs show `send-social-push` returning 200
- [ ] Verify `delivered: true` is set on the notification row in `community_notifications`

🤖 Generated with [Claude Code](https://claude.com/claude-code)