### PR TITLE
fix: repair circle lifecycle — circles now close after 14 days

### DIFF
--- a/unify-front-end/app/community-matching/circle/[circleId]/chat.tsx
+++ b/unify-front-end/app/community-matching/circle/[circleId]/chat.tsx
@@ -134,6 +134,10 @@ export default function CircleChatScreen() {
     enabled: !!circleId,
   });
 
+  const circleExpired =
+    circle?.status === 'ended' ||
+    (circle != null && new Date(circle.ends_at) <= new Date());
+
   const memberLookup = useMemo(() => {
     const map: Record<string, CommunityCircleMemberProfile> = {};
     members?.forEach(member => {
@@ -355,7 +359,7 @@ export default function CircleChatScreen() {
 
   const handleSend = async () => {
     const trimmed = text.trim();
-    if (!trimmed || !circleId || circle?.status === 'ended') {
+    if (!trimmed || !circleId || circleExpired) {
       return;
     }
 
@@ -545,8 +549,7 @@ export default function CircleChatScreen() {
     return items;
   }, [currentUser?.id, messages]);
 
-  const inputDisabled =
-    circle?.status === 'ended' || membership?.left_at !== null;
+  const inputDisabled = circleExpired || membership?.left_at !== null;
 
   return (
     <View style={styles.root}>
@@ -595,7 +598,7 @@ export default function CircleChatScreen() {
           </View>
         )}
 
-        {circle?.status === 'ended' && (
+        {circleExpired && (
           <View style={styles.banner}>
             <Text style={styles.bannerText}>
               This circle has ended. Chat is read-only.

--- a/unify-front-end/app/community-matching/circle/[circleId]/index.tsx
+++ b/unify-front-end/app/community-matching/circle/[circleId]/index.tsx
@@ -68,7 +68,8 @@ export default function CircleDetailsScreen() {
     enabled: !!circleId,
   });
 
-  const isActive = circle?.status === 'active';
+  const isActive =
+    circle?.status === 'active' && new Date(circle.ends_at) > new Date();
   const hasJoinedChat = !!membership?.joined_at && !membership.left_at;
   const hasLeftCircle = !!membership?.left_at;
 

--- a/unify-front-end/services/matching/circles.ts
+++ b/unify-front-end/services/matching/circles.ts
@@ -56,6 +56,12 @@ export const getActiveCircleMembership =
     const row = data as any;
     const circle = row.community_circles;
 
+    // Client-side guard: treat circles past their ends_at as inactive even
+    // if the backend hasn't flipped the status yet (cron runs every 3 min).
+    if (new Date(circle.ends_at) <= new Date()) {
+      return null;
+    }
+
     return {
       id: row.id,
       circle_id: row.circle_id,

--- a/unify-front-end/supabase/migrations/20260414_zzz_circle_lifecycle_cron.sql
+++ b/unify-front-end/supabase/migrations/20260414_zzz_circle_lifecycle_cron.sql
@@ -1,0 +1,106 @@
+-- ============================================================================
+-- Direct SQL lifecycle for circles: closes expired circles via pg_cron
+-- without relying on the edge function HTTP roundtrip.
+-- ============================================================================
+
+-- 1. SQL function that closes expired circles directly in the database.
+--    Runs every 3 minutes via pg_cron. Idempotent — safe to overlap with
+--    the edge function if it also runs.
+create or replace function public.close_expired_circles_cron()
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  _circle_ids uuid[];
+  _closed_count integer := 0;
+begin
+  -- Collect active circles past their ends_at
+  select array_agg(id) into _circle_ids
+  from community_circles
+  where status = 'active'
+    and ends_at <= now();
+
+  if _circle_ids is null or array_length(_circle_ids, 1) is null then
+    return jsonb_build_object('closed', 0);
+  end if;
+
+  -- Mark circles as ended
+  update community_circles
+  set status = 'ended'
+  where id = any(_circle_ids)
+    and status = 'active';
+
+  get diagnostics _closed_count = row_count;
+
+  -- Insert closing system messages (dedupe_key prevents duplicates)
+  insert into community_messages
+    (circle_id, sender_user_id, content, message_type, metadata, dedupe_key)
+  select
+    cid,
+    null,
+    'This circle has wrapped up. Say thanks, follow one another, and keep the support going beyond Circles.',
+    'system_notice',
+    '{"kind": "circle_ended"}'::jsonb,
+    'system:circle-ended'
+  from unnest(_circle_ids) as cid
+  on conflict (circle_id, dedupe_key) do nothing;
+
+  -- Notify active members that their circle ended
+  insert into community_notifications
+    (user_id, type, title, body, data)
+  select
+    m.user_id,
+    'circle_ended',
+    'Your circle has wrapped up',
+    'Say thanks, follow one another, and keep the support going.',
+    jsonb_build_object('circle_id', m.circle_id)
+  from community_circle_members m
+  where m.circle_id = any(_circle_ids)
+    and m.left_at is null;
+
+  return jsonb_build_object('closed', _closed_count);
+end;
+$$;
+
+revoke execute on function public.close_expired_circles_cron() from public, anon, authenticated;
+grant execute on function public.close_expired_circles_cron() to postgres, service_role;
+
+-- 2. Schedule the lifecycle cron (every 3 minutes, same cadence as matchmaking)
+do $$
+declare
+  _job_id bigint;
+begin
+  -- Remove any existing job with this name
+  for _job_id in
+    select jobid from cron.job where jobname = 'close-expired-circles'
+  loop
+    perform cron.unschedule(_job_id);
+  end loop;
+
+  perform cron.schedule(
+    'close-expired-circles',
+    '*/3 * * * *',
+    'select public.close_expired_circles_cron()'
+  );
+end;
+$$;
+
+-- 3. Add matchmake_api_key to vault so the existing cron trigger can
+--    authenticate against the edge function for matchmaking.
+--    Uses gen_random_uuid() as a simple shared secret.
+do $$
+begin
+  -- Only insert if the secret doesn't already exist
+  if not exists (
+    select 1 from vault.decrypted_secrets where name = 'matchmake_api_key'
+  ) then
+    perform vault.create_secret(
+      gen_random_uuid()::text,
+      'matchmake_api_key',
+      'Shared secret for cron → matchmake-circles edge function auth'
+    );
+  end if;
+end;
+$$;

--- a/unify-front-end/supabase/migrations/20260414_zzz_circle_lifecycle_cron.sql
+++ b/unify-front-end/supabase/migrations/20260414_zzz_circle_lifecycle_cron.sql
@@ -47,7 +47,7 @@ begin
   from unnest(_circle_ids) as cid
   on conflict (circle_id, dedupe_key) do nothing;
 
-  -- Notify active members that their circle ended
+  -- Notify active members that their circle ended (skip duplicates)
   insert into community_notifications
     (user_id, type, title, body, data)
   select
@@ -58,7 +58,13 @@ begin
     jsonb_build_object('circle_id', m.circle_id)
   from community_circle_members m
   where m.circle_id = any(_circle_ids)
-    and m.left_at is null;
+    and m.left_at is null
+    and not exists (
+      select 1 from community_notifications n
+      where n.user_id = m.user_id
+        and n.type = 'circle_ended'
+        and n.data->>'circle_id' = m.circle_id::text
+    );
 
   return jsonb_build_object('closed', _closed_count);
 end;


### PR DESCRIPTION
## Summary

- **Root cause**: The cron→edge function auth pipeline was returning 401 on every call since ~March 24, preventing `closeExpiredCircles` from running. 6 circles were stuck as `active` 10–20 days past their `ends_at`.
- **SQL cron**: Added `close_expired_circles_cron()` PL/pgSQL function called directly by pg_cron every 3 minutes, bypassing the fragile HTTP roundtrip entirely. This is the belt-and-suspenders layer that ensures circles always close on time.
- **Auth fix**: Added `matchmake_api_key` to the Supabase vault and set it as an edge function secret, restoring the `x-api-key` auth path so matchmaking also works again.
- **Client guard**: Added `ends_at` checks in the circles service, detail screen, and chat screen so the UI treats expired circles as ended even in the ~3 min window before the backend flips the status.

## Changes

| File | What |
|------|------|
| `supabase/migrations/20260414_zzz_circle_lifecycle_cron.sql` | New `close_expired_circles_cron()` function + pg_cron schedule + vault secret for edge function auth |
| `services/matching/circles.ts` | Client-side `ends_at` guard in `getActiveCircleMembership` |
| `app/community-matching/circle/[circleId]/index.tsx` | `isActive` now also checks `ends_at` |
| `app/community-matching/circle/[circleId]/chat.tsx` | `circleExpired` flag used for input disable + banner + send guard |

## Already deployed

The migration, vault secret, and edge function (v25) have been deployed to production. Results verified:
- 6 overdue circles closed with proper closing messages and member notifications
- First successful matching run in 21 days (200 OK, 2 new circles created)
- Both cron jobs (`close-expired-circles` and `community-matching-schedule`) running and succeeding

## Test plan

- [x] Verified 0 overdue active circles remaining in production
- [x] Verified closing messages inserted for all 6 circles
- [x] Verified `circle_ended` notifications sent to all active members
- [x] Verified edge function returns 200 (was 401 for 21 days)
- [x] Verified new matching run created with 2 circles from 9 waiting users
- [x] Verified both pg_cron jobs fire and succeed
- [x] TypeScript compiles clean (pre-existing error in unrelated file only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Circles now automatically expire and transition to read-only status based on their scheduled end time.

* **Bug Fixes**
  * Chat and interface now consistently treat time-expired circles as inactive, preventing messages on expired circles.
  * Added member notifications when circles reach their end time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->