### PR TITLE
fix: security hardening — privilege escalation, missing RLS, rate limiting

### DIFF
--- a/unify-front-end/hooks/companion/useSendMessage.ts
+++ b/unify-front-end/hooks/companion/useSendMessage.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { callGeminiAPI } from '@/utils/gemini';
 import { useChatbotUsage } from '@/hooks/companion/useChatbotUsage';
-import { useUpdateChatbotUsage } from '@/hooks/companion/useUpdateChatbotUsage';
 import { useCreateConversation } from '@/hooks/companion/useCreateConversation';
 import { useSaveMessage } from '@/hooks/companion/useSaveMessage';
 import {
@@ -36,8 +36,8 @@ export const useSendMessage = ({
   const [lastVerified, setLastVerified] = useState<string | undefined>(
     undefined
   );
+  const queryClient = useQueryClient();
   const { data: usage } = useChatbotUsage();
-  const updateUsage = useUpdateChatbotUsage();
   const createConversation = useCreateConversation();
   const saveMessage = useSaveMessage();
   const { trackCompanionResponseReceived } = useAnalytics();
@@ -97,11 +97,9 @@ export const useSendMessage = ({
       );
       const responseTimeMs = Date.now() - apiStartTime;
 
-      // Update usage count only for non-premium users
-      if (!isPremium) {
-        const newMessageCount = (usage?.message_count ?? 0) + 1;
-        updateUsage.mutate(newMessageCount);
-      }
+      // Server incremented usage atomically during rag-query.
+      // Invalidate the cache so the UI picks up the new count.
+      queryClient.invalidateQueries({ queryKey: ['chatbot-usage'] });
 
       // Parse the response (includes queryType, disclaimer, suggestedNextSteps, and tokenUsage)
       const {

--- a/unify-front-end/scripts/sync-sanity-modules.ts
+++ b/unify-front-end/scripts/sync-sanity-modules.ts
@@ -13,7 +13,7 @@
  * Required env vars (from .env or shell):
  *   SANITY_PROJECT_ID or EXPO_PUBLIC_SANITY_PROJECT_ID
  *   SANITY_DATASET or EXPO_PUBLIC_SANITY_DATASET (default: production)
- *   SANITY_API_TOKEN or EXPO_PUBLIC_SANITY_TOKEN (read token)
+ *   SANITY_API_TOKEN or SANITY_TOKEN (read token)
  *   SUPABASE_URL or EXPO_PUBLIC_SUPABASE_URL
  *   SUPABASE_SERVICE_ROLE_KEY
  */
@@ -33,7 +33,7 @@ const SANITY_DATASET =
   process.env.SANITY_DATASET ||
   process.env.EXPO_PUBLIC_SANITY_DATASET ||
   'production';
-const SANITY_API_TOKEN = process.env.SANITY_API_TOKEN;
+const SANITY_API_TOKEN = process.env.SANITY_API_TOKEN || process.env.SANITY_TOKEN;
 const SUPABASE_URL =
   process.env.SUPABASE_URL || process.env.EXPO_PUBLIC_SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/unify-front-end/services/companion/upsertChatbotUsage.ts
+++ b/unify-front-end/services/companion/upsertChatbotUsage.ts
@@ -1,33 +1,15 @@
-import { supabase } from '@/lib/supabase';
-
+/**
+ * Client-side usage tracking is now read-only.
+ * The server (rag-query edge function) increments message_count atomically via
+ * the increment_chatbot_usage RPC. This function is kept as a no-op so existing
+ * callers don't break — the query cache is invalidated to pick up the
+ * server-side increment.
+ */
 export const upsertChatbotUsage = async (
-  new_message_count: number
+  _new_message_count: number
 ): Promise<boolean> => {
-  try {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) throw new Error('No authenticated user');
-
-    const { error } = await supabase.from('chatbot_usage').upsert(
-      {
-        user_id: user.id,
-        message_count: new_message_count,
-        last_message_at: new Date().toISOString(),
-      },
-      {
-        onConflict: 'user_id',
-      }
-    );
-
-    if (error) {
-      console.error('Error upserting chatbot usage:', error);
-      return false;
-    }
-
-    return true;
-  } catch (error) {
-    console.error('Error in upsertChatbotUsage:', error);
-    return false;
-  }
+  // No-op: server handles the increment. The useUpdateChatbotUsage hook
+  // invalidates the chatbot-usage query on success, which re-fetches
+  // the real count from the DB.
+  return true;
 };

--- a/unify-front-end/services/groups/sendGroupRequestEmail.ts
+++ b/unify-front-end/services/groups/sendGroupRequestEmail.ts
@@ -1,3 +1,5 @@
+import { supabase } from '@/lib/supabase';
+
 type GroupRequestPayload = {
   groupName: string;
   audience: string;
@@ -6,31 +8,13 @@ type GroupRequestPayload = {
   extraNotes?: string;
 };
 
-const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
-const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
-
 export async function sendGroupRequestEmail(payload: GroupRequestPayload) {
-  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-    throw new Error(
-      'Missing Supabase env vars (EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_ANON_KEY).'
-    );
-  }
-
-  const url = `${SUPABASE_URL}/functions/v1/request-group`;
-
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
-    },
-    body: JSON.stringify(payload),
+  const { data, error } = await supabase.functions.invoke('request-group', {
+    body: payload,
   });
 
-  const data = await res.json().catch(() => ({}));
-
-  if (!res.ok) {
-    throw new Error(data?.error ?? 'Edge function failed.');
+  if (error) {
+    throw new Error(error.message ?? 'Edge function failed.');
   }
 
   return data;

--- a/unify-front-end/supabase/functions/public-onboarding-profile/index.ts
+++ b/unify-front-end/supabase/functions/public-onboarding-profile/index.ts
@@ -52,8 +52,17 @@ Deno.serve(async (req: Request) => {
     const body = await req.json().catch(() => ({}));
     const userId = body?.userId;
 
-    if (!userId) {
+    if (!userId || typeof userId !== 'string') {
       return new Response(JSON.stringify({ error: 'Missing userId' }), {
+        status: 400,
+        headers: responseHeaders,
+      });
+    }
+
+    // Validate UUID format to prevent injection
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    if (!UUID_RE.test(userId)) {
+      return new Response(JSON.stringify({ error: 'Invalid userId format' }), {
         status: 400,
         headers: responseHeaders,
       });

--- a/unify-front-end/supabase/functions/rag-query/index.ts
+++ b/unify-front-end/supabase/functions/rag-query/index.ts
@@ -596,7 +596,43 @@ Deno.serve(async (req: Request) => {
     );
 
     const authenticatedUserId = await authPromise;
-    const effectiveUserId = authenticatedUserId || null;
+
+    // Require authentication — reject unauthenticated requests to prevent
+    // abuse and uncontrolled API credit consumption.
+    if (!authenticatedUserId) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const effectiveUserId = authenticatedUserId;
+
+    // Server-side daily rate limit — prevent bypassing the client-side limit
+    const DAILY_MESSAGE_LIMIT = 30; // generous server-side cap
+    const { data: usageRow } = await supabase
+      .from('chatbot_usage')
+      .select('message_count, last_message_at')
+      .eq('user_id', effectiveUserId)
+      .maybeSingle();
+
+    const today = new Date().toISOString().split('T')[0];
+    const lastDate = usageRow?.last_message_at?.split('T')[0];
+    const todayCount = lastDate === today ? (usageRow?.message_count ?? 0) : 0;
+
+    // Check premium status server-side (not from client request)
+    const { data: userData } = await supabase
+      .from('users')
+      .select('is_premium')
+      .eq('id', effectiveUserId)
+      .single();
+
+    if (!userData?.is_premium && todayCount >= DAILY_MESSAGE_LIMIT) {
+      return new Response(
+        JSON.stringify({ error: 'Daily message limit reached. Try again tomorrow.' }),
+        { status: 429, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
 
     if (
       requestUserId &&

--- a/unify-front-end/supabase/functions/rag-query/index.ts
+++ b/unify-front-end/supabase/functions/rag-query/index.ts
@@ -608,26 +608,15 @@ Deno.serve(async (req: Request) => {
 
     const effectiveUserId = authenticatedUserId;
 
-    // Server-side daily rate limit — prevent bypassing the client-side limit
-    const DAILY_MESSAGE_LIMIT = 30; // generous server-side cap
-    const { data: usageRow } = await supabase
-      .from('chatbot_usage')
-      .select('message_count, last_message_at')
-      .eq('user_id', effectiveUserId)
-      .maybeSingle();
+    // Atomic rate limit: check + increment in one RPC (fail-closed).
+    // Returns false if over the daily cap or on any DB error.
+    const DAILY_MESSAGE_LIMIT = 30;
+    const { data: allowed, error: quotaError } = await supabase.rpc(
+      'check_and_increment_chatbot_usage',
+      { p_user_id: effectiveUserId, p_daily_limit: DAILY_MESSAGE_LIMIT }
+    );
 
-    const today = new Date().toISOString().split('T')[0];
-    const lastDate = usageRow?.last_message_at?.split('T')[0];
-    const todayCount = lastDate === today ? (usageRow?.message_count ?? 0) : 0;
-
-    // Check premium status server-side (not from client request)
-    const { data: userData } = await supabase
-      .from('users')
-      .select('is_premium')
-      .eq('id', effectiveUserId)
-      .single();
-
-    if (!userData?.is_premium && todayCount >= DAILY_MESSAGE_LIMIT) {
+    if (quotaError || allowed === false) {
       return new Response(
         JSON.stringify({ error: 'Daily message limit reached. Try again tomorrow.' }),
         { status: 429, headers: { 'Content-Type': 'application/json' } }

--- a/unify-front-end/supabase/functions/request-group/index.ts
+++ b/unify-front-end/supabase/functions/request-group/index.ts
@@ -1,3 +1,6 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+
 const RESEND_API_KEY = Deno.env.get('RESEND_API_KEY');
 const RESEND_FROM = Deno.env.get('RESEND_FROM'); // e.g. "Unify <noreply@unifysocial.ca>"
 const RESEND_TO = Deno.env.get('RESEND_TO'); // "contact@unifysocial.ca"
@@ -33,6 +36,9 @@ function sanitizeForSubject(str: string): string {
     .slice(0, 100); // Limit length
 }
 
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL');
+const SUPABASE_ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY');
+
 Deno.serve(async (req: Request) => {
   if (req.method !== 'POST') {
     return new Response('Method not allowed', { status: 405 });
@@ -41,6 +47,34 @@ Deno.serve(async (req: Request) => {
   if (!RESEND_API_KEY || !RESEND_FROM || !RESEND_TO) {
     return new Response(JSON.stringify({ error: 'Missing Resend env vars.' }), {
       status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Require authentication to prevent anonymous spam
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    return new Response(JSON.stringify({ error: 'Missing Supabase env vars.' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const token = req.headers.get('Authorization')?.replace('Bearer ', '');
+  if (!token) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const authClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+    auth: { persistSession: false },
+  });
+  const { data: { user }, error: authError } = await authClient.auth.getUser();
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Invalid session' }), {
+      status: 401,
       headers: { 'Content-Type': 'application/json' },
     });
   }

--- a/unify-front-end/supabase/functions/request-group/index.ts
+++ b/unify-front-end/supabase/functions/request-group/index.ts
@@ -78,6 +78,7 @@ Deno.serve(async (req: Request) => {
       headers: { 'Content-Type': 'application/json' },
     });
   }
+  const authenticatedEmail = user.email?.trim().toLowerCase();
 
   let body: Payload;
   try {
@@ -101,6 +102,14 @@ Deno.serve(async (req: Request) => {
   // Validate email format
   if (!isValidEmail(requesterEmail.trim())) {
     return badRequest('Invalid requesterEmail format.');
+  }
+
+  // Bind to authenticated user's email — prevent impersonation via body
+  if (
+    !authenticatedEmail ||
+    requesterEmail.trim().toLowerCase() !== authenticatedEmail
+  ) {
+    return badRequest('requesterEmail must match the authenticated user.');
   }
 
   // Sanitize groupName for use in email subject
@@ -132,7 +141,7 @@ Deno.serve(async (req: Request) => {
       to: RESEND_TO,
       subject: `Group Request: ${sanitizedGroupName}`,
       html,
-      reply_to: requesterEmail,
+      reply_to: authenticatedEmail,
     }),
   });
 

--- a/unify-front-end/supabase/functions/sync-learn-modules/index.ts
+++ b/unify-front-end/supabase/functions/sync-learn-modules/index.ts
@@ -5,7 +5,7 @@ import { createClient } from 'jsr:@supabase/supabase-js@2';
  * Weekly / manual full sync: Sanity → learn_modules (upsert + delete orphans).
  *
  * Secrets (Supabase Dashboard → Edge Functions):
- *   SANITY_PROJECT_ID, SANITY_DATASET (optional), SANITY_API_TOKEN
+ *   SANITY_PROJECT_ID, SANITY_DATASET (optional), SANITY_API_TOKEN or SANITY_TOKEN
  *   SYNC_LEARN_MODULES_API_KEY — required; callers send x-api-key header
  *
  * Cron: pg_cron → trigger_sync_learn_modules() (see migration).
@@ -27,10 +27,10 @@ interface SanityModuleRow {
 async function fetchAllModulesFromSanity(): Promise<SanityModuleRow[]> {
   const projectId = Deno.env.get('SANITY_PROJECT_ID');
   const dataset = Deno.env.get('SANITY_DATASET') || 'production';
-  const token = Deno.env.get('SANITY_API_TOKEN');
+  const token = Deno.env.get('SANITY_API_TOKEN') || Deno.env.get('SANITY_TOKEN');
 
   if (!projectId || !token) {
-    throw new Error('Missing SANITY_PROJECT_ID or SANITY_API_TOKEN');
+    throw new Error('Missing SANITY_PROJECT_ID or SANITY_API_TOKEN/SANITY_TOKEN');
   }
 
   const query = encodeURIComponent(

--- a/unify-front-end/supabase/migrations/20260414_zzzz_security_hardening.sql
+++ b/unify-front-end/supabase/migrations/20260414_zzzz_security_hardening.sql
@@ -1,0 +1,134 @@
+-- Security hardening migration
+-- Fixes: privilege escalation via users table, missing RLS on community_matching_runs,
+--        client-writable chatbot usage counter, server-side content filter for posts
+
+-- =============================================================================
+-- 1. CRITICAL: Restrict users table UPDATE — prevent self-promotion to admin
+--    or self-granting premium status.
+--    The old policy "Users can update their own record" allows unrestricted
+--    column updates, so any authenticated user can set permissions='admin'.
+-- =============================================================================
+
+DROP POLICY IF EXISTS "Users can update their own record" ON public.users;
+
+-- New policy: users can update their own row, but permissions and is_premium
+-- must remain unchanged (only service_role / admin triggers can modify those).
+CREATE POLICY "Users can update their own safe fields"
+  ON public.users FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = id)
+  WITH CHECK (
+    auth.uid() = id
+    AND permissions IS NOT DISTINCT FROM (SELECT u.permissions FROM public.users u WHERE u.id = auth.uid())
+    AND is_premium  IS NOT DISTINCT FROM (SELECT u.is_premium  FROM public.users u WHERE u.id = auth.uid())
+  );
+
+-- =============================================================================
+-- 2. CRITICAL: Enable RLS on community_matching_runs
+--    Currently has no RLS and full anon+authenticated grants.
+-- =============================================================================
+
+ALTER TABLE public.community_matching_runs ENABLE ROW LEVEL SECURITY;
+
+-- Revoke broad grants — only service_role should manage matching runs
+REVOKE ALL ON public.community_matching_runs FROM anon;
+REVOKE ALL ON public.community_matching_runs FROM authenticated;
+
+-- Allow authenticated users to read (for UI status display), nothing else
+GRANT SELECT ON public.community_matching_runs TO authenticated;
+
+CREATE POLICY "Authenticated users can view matching runs"
+  ON public.community_matching_runs FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- =============================================================================
+-- 3. HIGH: Make chatbot_usage.message_count non-writable by clients
+--    Replace the permissive UPDATE policy with one that only allows updating
+--    last_message_at (cosmetic). The actual count increment happens via an
+--    atomic RPC function called from the edge function.
+-- =============================================================================
+
+DROP POLICY IF EXISTS "Auth users can update their own usage counts" ON public.chatbot_usage;
+
+-- Users can still read their own usage (existing SELECT policy stays)
+-- Users can still insert their initial row (existing INSERT policy stays)
+-- But UPDATE is now restricted: message_count and cost fields cannot change
+CREATE POLICY "Users can update own usage timestamp only"
+  ON public.chatbot_usage FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (
+    auth.uid() = user_id
+    AND message_count IS NOT DISTINCT FROM (SELECT cu.message_count FROM public.chatbot_usage cu WHERE cu.user_id = auth.uid())
+    AND total_tokens_used IS NOT DISTINCT FROM (SELECT cu.total_tokens_used FROM public.chatbot_usage cu WHERE cu.user_id = auth.uid())
+    AND total_estimated_cost_usd IS NOT DISTINCT FROM (SELECT cu.total_estimated_cost_usd FROM public.chatbot_usage cu WHERE cu.user_id = auth.uid())
+  );
+
+-- RPC function for edge functions to atomically increment usage (service_role only)
+CREATE OR REPLACE FUNCTION public.increment_chatbot_usage(
+  p_user_id uuid,
+  p_tokens bigint DEFAULT 0,
+  p_cost double precision DEFAULT 0
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.chatbot_usage (user_id, message_count, last_message_at, total_tokens_used, total_estimated_cost_usd)
+  VALUES (p_user_id, 1, now(), p_tokens, p_cost)
+  ON CONFLICT (user_id) DO UPDATE SET
+    message_count = chatbot_usage.message_count + 1,
+    last_message_at = now(),
+    total_tokens_used = chatbot_usage.total_tokens_used + p_tokens,
+    total_estimated_cost_usd = chatbot_usage.total_estimated_cost_usd + p_cost;
+END;
+$$;
+
+-- Only service_role can call this function
+REVOKE EXECUTE ON FUNCTION public.increment_chatbot_usage(uuid, bigint, double precision) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.increment_chatbot_usage(uuid, bigint, double precision) TO service_role;
+
+-- =============================================================================
+-- 4. HIGH: Server-side content filter for posts
+--    Rejects posts containing banned words, matching the client-side filter.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.check_post_content()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  normalized text;
+  banned text[] := ARRAY[
+    'nigger','nigga','chink','gook','spic','wetback','kike','beaner','coon',
+    'darkie','raghead','towelhead','redskin','injun','jap','cracker','honky',
+    'gringo','paki','faggot','fag','dyke','tranny','cunt','whore','slut',
+    'kill yourself','kys','go die','heil hitler','white power',
+    'white supremacy','death to'
+  ];
+  word text;
+BEGIN
+  -- Normalize: lowercase, strip zero-width chars, basic l33t speak
+  normalized := lower(NEW.content);
+  normalized := regexp_replace(normalized, '[\u200B\u200C\u200D\u2060\uFEFF\u00AD]', '', 'g');
+  normalized := translate(normalized, '013457@$', 'oieatsa');
+
+  FOREACH word IN ARRAY banned LOOP
+    IF normalized ~* ('\m' || word || '\M') THEN
+      RAISE EXCEPTION 'Content violates community guidelines'
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_check_post_content ON public.posts;
+CREATE TRIGGER trg_check_post_content
+  BEFORE INSERT OR UPDATE ON public.posts
+  FOR EACH ROW
+  EXECUTE FUNCTION public.check_post_content();

--- a/unify-front-end/supabase/migrations/20260414_zzzzz_security_hardening_v2.sql
+++ b/unify-front-end/supabase/migrations/20260414_zzzzz_security_hardening_v2.sql
@@ -1,0 +1,108 @@
+-- Security hardening v2 — fixes from code review
+-- 1. Drop client UPDATE on chatbot_usage entirely (last_message_at was still writable)
+-- 2. Fix increment_chatbot_usage to reset message_count on new day
+-- 3. Create atomic check_and_increment_chatbot_usage RPC (fail-closed)
+
+-- =============================================================================
+-- 1. Remove ALL client UPDATE access to chatbot_usage
+--    The v1 policy still allowed clients to modify last_message_at, which
+--    could be used to game the daily counter reset logic.
+-- =============================================================================
+
+DROP POLICY IF EXISTS "Users can update own usage timestamp only" ON public.chatbot_usage;
+-- No replacement — only service_role (via SECURITY DEFINER RPCs) can mutate rows.
+
+-- =============================================================================
+-- 2. Fix increment_chatbot_usage: reset message_count on day rollover
+--    Previously always incremented the lifetime total. After 30+ messages,
+--    users would be permanently blocked on the next day.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.increment_chatbot_usage(
+  p_user_id uuid,
+  p_tokens bigint DEFAULT 0,
+  p_cost double precision DEFAULT 0
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.chatbot_usage (user_id, message_count, last_message_at, total_tokens_used, total_estimated_cost_usd)
+  VALUES (p_user_id, 1, now(), p_tokens, p_cost)
+  ON CONFLICT (user_id) DO UPDATE SET
+    message_count = CASE
+      WHEN chatbot_usage.last_message_at::date = current_date
+        THEN chatbot_usage.message_count + 1
+      ELSE 1
+    END,
+    last_message_at = now(),
+    total_tokens_used = chatbot_usage.total_tokens_used + p_tokens,
+    total_estimated_cost_usd = chatbot_usage.total_estimated_cost_usd + p_cost;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.increment_chatbot_usage(uuid, bigint, double precision) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.increment_chatbot_usage(uuid, bigint, double precision) TO service_role;
+
+-- =============================================================================
+-- 3. Atomic check-and-increment: single RPC that either allows (increments +
+--    returns true) or denies (returns false). Fail-closed on any error.
+--    This replaces the separate SELECT + later increment in rag-query.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.check_and_increment_chatbot_usage(
+  p_user_id uuid,
+  p_daily_limit integer DEFAULT 30
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_is_premium boolean;
+  v_today_count integer;
+BEGIN
+  -- Check premium status (fail-closed: treat lookup failure as non-premium)
+  SELECT coalesce(is_premium, false) INTO v_is_premium
+    FROM public.users
+    WHERE id = p_user_id;
+
+  IF NOT FOUND THEN
+    RETURN false;  -- unknown user → deny
+  END IF;
+
+  -- Upsert usage row and get updated count atomically
+  INSERT INTO public.chatbot_usage (user_id, message_count, last_message_at)
+  VALUES (p_user_id, 1, now())
+  ON CONFLICT (user_id) DO UPDATE SET
+    message_count = CASE
+      WHEN chatbot_usage.last_message_at::date = current_date
+        THEN chatbot_usage.message_count + 1
+      ELSE 1
+    END,
+    last_message_at = now()
+  RETURNING message_count INTO v_today_count;
+
+  -- Premium users are always allowed
+  IF v_is_premium THEN
+    RETURN true;
+  END IF;
+
+  -- Non-premium: check the (already incremented) count against the limit.
+  -- If over, roll back the increment so it doesn't consume a slot.
+  IF v_today_count > p_daily_limit THEN
+    UPDATE public.chatbot_usage
+      SET message_count = message_count - 1
+      WHERE user_id = p_user_id;
+    RETURN false;
+  END IF;
+
+  RETURN true;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.check_and_increment_chatbot_usage(uuid, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.check_and_increment_chatbot_usage(uuid, integer) TO service_role;


### PR DESCRIPTION
## Summary

Comprehensive security hardening addressing critical and high-severity vulnerabilities found during a full security audit.

### Critical fixes
- **Privilege escalation closed** — The `users` table UPDATE RLS policy now prevents clients from modifying `permissions` or `is_premium` columns. Previously any authenticated user could self-promote to admin.
- **RLS enabled on `community_matching_runs`** — Table was fully open (no RLS, full anon+authenticated grants). Now locked to read-only for authenticated, write-only for service_role.

### High-severity fixes
- **Server-side rate limiting on `rag-query`** — 30 messages/day cap enforced server-side for non-premium users. Auth now required (was optional). Prevents unlimited AI API credit consumption.
- **Server-side content filter** — `BEFORE INSERT/UPDATE` trigger on `posts` table rejects banned words, matching the client-side filter. Posts can no longer bypass moderation by calling Supabase directly.
- **`request-group` now requires auth** — Was fully unauthenticated; anyone could spam group request emails.
- **UUID validation on `public-onboarding-profile`** — Input validation added to prevent malformed IDs.
- **`chatbot_usage` locked down** — Clients can no longer reset their own `message_count`. Server increments atomically via `increment_chatbot_usage` RPC.
- **Removed `EXPO_PUBLIC_` prefix from Sanity token** — Renamed to `SANITY_TOKEN` to prevent client bundling. Removed AWS credentials with `EXPO_PUBLIC_` prefix from `.env`.

### Client-side changes
- `sendGroupRequestEmail` now uses `supabase.functions.invoke()` (sends user JWT instead of anon key)
- `upsertChatbotUsage` converted to no-op (server handles increment)
- `sync-sanity-modules` updated to read `SANITY_TOKEN` fallback

### Deployment status
- Migration applied to production ✅
- Edge functions deployed: `rag-query`, `request-group`, `public-onboarding-profile` ✅

## Test plan

- [ ] Verify normal user profile updates (username, bio, pronouns) still work
- [ ] Verify admin actions (delete post, pin post) still work for admin users
- [ ] Test companion chat — messages should work within daily limit, hit 429 after limit
- [ ] Test group request form — should succeed when logged in, fail without auth
- [ ] Test post creation — normal content passes, banned words rejected with clear error
- [ ] Verify circle matching cron jobs still run (service_role access unaffected)
- [ ] Confirm `community_matching_runs` is readable but not writable by app users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented daily message limits (30 messages/day) for non-premium users in chatbot interactions.
  * Added server-side content filtering for banned words in posts.

* **Bug Fixes**
  * Enhanced request validation with stricter ID format checking.

* **Security**
  * Enforced authentication requirements for API requests.
  * Implemented server-side premium status verification.
  * Restricted user data modification to prevent unauthorized changes to account permissions and premium status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->