### PR TITLE
feat(learn): Resources tab for partner directory

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -10,3 +10,32 @@
 **Context:** The crawler's change detection logging (from the RAG automated ingestion pipeline) provides the trigger data. Push token storage and delivery service are the missing pieces.
 **Effort:** XL (human) → L (CC)
 **Depends on:** RAG automated ingestion pipeline (change detection in crawl_logs), Personalization Engine (provides `onboarding_profiles` with city/province and `personalize` edge function pattern for matching policy changes to user profiles — see `docs/designs/personalization-engine.md`)
+
+## P2 — Medium Priority
+
+### Component Test Infrastructure (React Testing Library)
+**What:** Set up `@testing-library/react-native` and configure Jest for component-level tests. Establish first component test patterns so future features can include component-level regression coverage by default.
+**Why:** Project currently has only utility/service tests in `__tests__/`. Component-heavy features (Resources, Checklist, Learn) ship without component-level regression coverage. As the app grows, the absence of this infrastructure compounds into a risk every release.
+**Pros:** Every future feature can ship with component tests at marginal cost. Establishes a culture where UI regressions get caught pre-merge.
+**Cons:** Initial setup work + introducing a new test pattern means ramp time for the team. Maintenance burden on test fixtures.
+**Context:** Surfaced during plan-eng-review of the Referral Monetization (Resources tab) design doc. The Resources feature shipped with manual QA only; component tests were deferred. Future features should not have to repeat that decision.
+**Effort:** M (human) → S (CC)
+**Depends on:** —
+
+### i18n Extraction for Resources Copy
+**What:** When multi-language support lands, extract hardcoded copy from the Resources screens (disclosure card, category descriptions, partner CTAs, error toasts, "How Unify partnerships work" link text) to a strings file consumed by an i18n library.
+**Why:** Newcomer audience strongly implies multi-language support will be on the roadmap. Newcomers in their first 6-12 months often have stronger comprehension in their native language than in English. Hardcoded copy in components becomes harder to extract once it's spread across files.
+**Pros:** Makes the feature ready for the broader i18n initiative without rework.
+**Cons:** Pure scope creep until i18n is actually committed to.
+**Context:** Surfaced during plan-eng-review of Referral Monetization (Resources tab). Flagged as code quality issue Q-3 — copy hardcoded in JSX. No i18n library currently in the project.
+**Effort:** S (human) → S (CC)
+**Depends on:** Project-level decision to add i18n (e.g., `i18n-js`, `react-i18next`, or Expo's localization solution)
+
+### Intersection-based View Tracking for Partner Cards
+**What:** Switch the `resources_partner_card_viewed` PostHog event from on-render firing to intersection/scroll-based detection (only fire when a card is actually visible in the viewport, with debouncing).
+**Why:** At V1 scale (2 partners) on-render firing is fine. Once a category has 5+ partners, on-render fires events for cards the user never actually scrolls into view, polluting analytics with noise and inflating event counts in PostHog.
+**Pros:** Cleaner analytics, accurate "saw this partner" attribution. Lower PostHog event volume = lower cost.
+**Cons:** React Native intersection observation requires `onLayout` + scroll position math (no native API equivalent to web's IntersectionObserver). Implementation is non-trivial.
+**Context:** Surfaced during plan-eng-review of Referral Monetization (Resources tab). Flagged as performance watch zone for V2 when partner count grows.
+**Effort:** M (human) → S (CC)
+**Depends on:** Resources tab live in production with partner count ≥5 per category

--- a/unify-front-end/app/(tabs)/Learn/index.tsx
+++ b/unify-front-end/app/(tabs)/Learn/index.tsx
@@ -26,6 +26,10 @@ import {
 import TabHeader from '@/components/home/HomeHeader';
 import { useProgressCache } from '@/hooks/progress/useProgressCache';
 import AnnouncementModal from '@/components/common/AnnouncementModal';
+import SegmentedControl from '@/components/learn/Resources/SegmentedControl';
+import ResourcesView from '@/components/learn/Resources/ResourcesView';
+
+type LearnView = 'articles' | 'resources';
 
 export default function Learn() {
   useProgressCache();
@@ -33,6 +37,7 @@ export default function Learn() {
   const isFocused = useIsFocused();
   const [heroIndex, setHeroIndex] = React.useState(0);
   const [refreshing, setRefreshing] = React.useState(false);
+  const [view, setView] = React.useState<LearnView>('articles');
   const { width } = useWindowDimensions();
   const sliderRef = React.useRef<ScrollView>(null);
 
@@ -92,6 +97,17 @@ export default function Learn() {
       <TabHeader variant='minimal' />
       <View style={styles.container}>
         <StatusBar style='dark' />
+        <SegmentedControl<LearnView>
+          value={view}
+          onChange={setView}
+          options={[
+            { value: 'articles', label: 'Articles' },
+            { value: 'resources', label: 'Resources' },
+          ]}
+        />
+        {view === 'resources' ? (
+          <ResourcesView />
+        ) : (
         <ScrollView
           contentContainerStyle={styles.scrollContent}
           refreshControl={
@@ -312,6 +328,7 @@ export default function Learn() {
             </>
           )}
         </ScrollView>
+        )}
       </View>
       <AnnouncementModal
         storageKey='announcement.learnHighlights.v1'

--- a/unify-front-end/components/learn/Resources/CategoryDetail.tsx
+++ b/unify-front-end/components/learn/Resources/CategoryDetail.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import {
+  PARTNER_CATEGORY_LABELS,
+  PARTNER_CATEGORY_DESCRIPTIONS,
+  type PartnerCategory,
+} from '@/types/partner';
+import { getPartnersByCategory } from '@/constants/Partners';
+import PartnerCard from './PartnerCard';
+
+type Props = {
+  category: PartnerCategory;
+  onBack: () => void;
+};
+
+export default function CategoryDetail({ category, onBack }: Props) {
+  const label = PARTNER_CATEGORY_LABELS[category];
+  const description = PARTNER_CATEGORY_DESCRIPTIONS[category];
+  const partners = getPartnersByCategory(category);
+
+  return (
+    <View style={styles.root}>
+      <TouchableOpacity
+        onPress={onBack}
+        style={styles.backRow}
+        activeOpacity={0.7}
+        accessibilityRole='button'
+        accessibilityLabel='Back to categories'
+      >
+        <Feather name='chevron-left' size={20} color='#343232' />
+        <Text style={styles.backText}>Categories</Text>
+      </TouchableOpacity>
+
+      <Text style={styles.title}>{label}</Text>
+      <Text style={styles.description}>{description}</Text>
+
+      {partners.length === 0 ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>
+            No active partners in this category yet.
+          </Text>
+        </View>
+      ) : (
+        partners.map((partner, idx) => (
+          <PartnerCard key={partner.slug} partner={partner} position={idx} />
+        ))
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  backRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+    paddingVertical: 4,
+  },
+  backText: {
+    fontSize: 15,
+    fontWeight: '500',
+    color: '#343232',
+    marginLeft: 4,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#000',
+    marginBottom: 6,
+  },
+  description: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: '#575757',
+    marginBottom: 16,
+  },
+  empty: {
+    paddingVertical: 32,
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontSize: 14,
+    color: '#878787',
+  },
+});

--- a/unify-front-end/components/learn/Resources/CategoryListItem.tsx
+++ b/unify-front-end/components/learn/Resources/CategoryListItem.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { MaterialCommunityIcons, Feather } from '@expo/vector-icons';
+import {
+  PARTNER_CATEGORY_LABELS,
+  PARTNER_CATEGORY_ICONS,
+  PARTNER_CATEGORY_DESCRIPTIONS,
+  type PartnerCategory,
+} from '@/types/partner';
+
+type Props = {
+  category: PartnerCategory;
+  partnerCount: number;
+  onPress: () => void;
+};
+
+export default function CategoryListItem({
+  category,
+  partnerCount,
+  onPress,
+}: Props) {
+  const label = PARTNER_CATEGORY_LABELS[category];
+  const description = PARTNER_CATEGORY_DESCRIPTIONS[category];
+  const iconName = PARTNER_CATEGORY_ICONS[category];
+
+  return (
+    <TouchableOpacity
+      activeOpacity={0.85}
+      onPress={onPress}
+      style={styles.container}
+      accessibilityRole='button'
+      accessibilityLabel={`${label}, ${partnerCount} trusted partner${
+        partnerCount === 1 ? '' : 's'
+      }`}
+    >
+      <View style={styles.iconWrap}>
+        <MaterialCommunityIcons
+          name={iconName as any}
+          size={24}
+          color='#343232'
+        />
+      </View>
+      <View style={styles.body}>
+        <Text style={styles.label}>{label}</Text>
+        <Text style={styles.subtitle} numberOfLines={2}>
+          {partnerCount} trusted partner{partnerCount === 1 ? '' : 's'}
+          {' · '}
+          {description}
+        </Text>
+      </View>
+      <Feather name='chevron-right' size={20} color='#878787' />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    paddingVertical: 14,
+    paddingHorizontal: 14,
+    marginBottom: 10,
+    shadowColor: '#575757',
+    shadowOpacity: 0.06,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  iconWrap: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    backgroundColor: '#F2F2F2',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+  },
+  body: {
+    flex: 1,
+    paddingRight: 8,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#343232',
+    marginBottom: 2,
+  },
+  subtitle: {
+    fontSize: 13,
+    color: '#575757',
+    lineHeight: 18,
+  },
+});

--- a/unify-front-end/components/learn/Resources/DisclosureCard.tsx
+++ b/unify-front-end/components/learn/Resources/DisclosureCard.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+
+/**
+ * Persistent transparency note shown at the top of the Resources view.
+ * Builds trust by being upfront about the referral relationship.
+ */
+export default function DisclosureCard() {
+  return (
+    <View style={styles.container}>
+      <MaterialCommunityIcons
+        name='information-outline'
+        size={18}
+        color='#5A5A5A'
+        style={styles.icon}
+      />
+      <Text style={styles.text}>
+        Unify earns a referral fee when you use these partners. We only feature
+        services we believe deliver real value to newcomers.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: '#F8F9FA',
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 16,
+  },
+  icon: {
+    marginRight: 8,
+    marginTop: 1,
+  },
+  text: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 18,
+    color: '#5A5A5A',
+  },
+});

--- a/unify-front-end/components/learn/Resources/PartnerCard.tsx
+++ b/unify-front-end/components/learn/Resources/PartnerCard.tsx
@@ -1,0 +1,270 @@
+import React, { useEffect } from 'react';
+import {
+  View,
+  Text,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+  Linking,
+  Alert,
+} from 'react-native';
+import { Feather, MaterialCommunityIcons } from '@expo/vector-icons';
+import * as Clipboard from 'expo-clipboard';
+import type { Partner } from '@/types/partner';
+import { buildPartnerUrl } from '@/utils/partners';
+import { useAnalytics } from '@/utils/analytics';
+
+type Props = {
+  partner: Partner;
+  /** Position in its category list, 0-indexed. Used for analytics. */
+  position: number;
+};
+
+export default function PartnerCard({ partner, position }: Props) {
+  const {
+    trackResourcesPartnerCardViewed,
+    trackResourcesPartnerCtaTapped,
+    trackResourcesPartnerCtaFailed,
+    trackResourcesPartnerPromoCopied,
+  } = useAnalytics();
+
+  // Fire view event on mount.
+  // V1: on-render. Tracked TODO: switch to intersection-based at scale.
+  useEffect(() => {
+    trackResourcesPartnerCardViewed(partner.slug, partner.category, position);
+  }, [
+    partner.slug,
+    partner.category,
+    position,
+    trackResourcesPartnerCardViewed,
+  ]);
+
+  const handleCopyPromo = async () => {
+    if (!partner.promoCode) return;
+    try {
+      await Clipboard.setStringAsync(partner.promoCode);
+      trackResourcesPartnerPromoCopied(partner.slug);
+      Alert.alert(
+        'Copied',
+        `Promo code ${partner.promoCode} copied to clipboard.`
+      );
+    } catch {
+      Alert.alert(
+        'Copy failed',
+        'Could not copy the promo code. Please try again.'
+      );
+    }
+  };
+
+  const handleVisit = async () => {
+    const url = buildPartnerUrl(partner, 'learn_resources');
+    // Fire intent event before opening — captures intent even if open fails.
+    trackResourcesPartnerCtaTapped(partner.slug, partner.category);
+    try {
+      const supported = await Linking.canOpenURL(url);
+      if (!supported) {
+        throw new Error('URL_NOT_SUPPORTED');
+      }
+      await Linking.openURL(url);
+    } catch (err) {
+      const errorType =
+        err instanceof Error ? err.message : 'unknown_open_error';
+      trackResourcesPartnerCtaFailed(partner.slug, errorType);
+      try {
+        await Clipboard.setStringAsync(url);
+        Alert.alert(
+          "Couldn't open link",
+          'The link has been copied to your clipboard.'
+        );
+      } catch {
+        Alert.alert(
+          "Couldn't open link",
+          'Please try again, or visit the partner directly.'
+        );
+      }
+    }
+  };
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <View style={styles.logoWrap}>
+          <Image
+            source={partner.logo}
+            style={styles.logo}
+            resizeMode='contain'
+          />
+        </View>
+        <View style={styles.headerText}>
+          <Text style={styles.name} numberOfLines={2}>
+            {partner.name}
+          </Text>
+          <View style={styles.badge}>
+            <Feather name='check-circle' size={12} color='#0A7E3F' />
+            <Text style={styles.badgeText}>Unify Partner</Text>
+          </View>
+        </View>
+      </View>
+
+      <Text style={styles.tagline}>{partner.tagline}</Text>
+
+      {partner.benefits.length > 0 && (
+        <View style={styles.benefits}>
+          {partner.benefits.slice(0, 5).map((benefit, idx) => (
+            <View key={idx} style={styles.benefitRow}>
+              <MaterialCommunityIcons
+                name='check'
+                size={16}
+                color='#0A7E3F'
+                style={styles.benefitIcon}
+              />
+              <Text style={styles.benefitText}>{benefit}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {partner.promoCode && (
+        <TouchableOpacity
+          style={styles.promoRow}
+          onPress={handleCopyPromo}
+          activeOpacity={0.7}
+          accessibilityRole='button'
+          accessibilityLabel={`Copy promo code ${partner.promoCode}`}
+        >
+          <Text style={styles.promoLabel}>Promo code:</Text>
+          <Text style={styles.promoCode}>{partner.promoCode}</Text>
+          <Feather name='copy' size={14} color='#575757' />
+        </TouchableOpacity>
+      )}
+
+      <TouchableOpacity
+        style={styles.cta}
+        onPress={handleVisit}
+        activeOpacity={0.85}
+        accessibilityRole='button'
+        accessibilityLabel={`${partner.ctaLabel} with ${partner.name}`}
+      >
+        <Text style={styles.ctaText}>{partner.ctaLabel}</Text>
+        <Feather name='arrow-right' size={16} color='#FFFFFF' />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 20,
+    padding: 16,
+    marginBottom: 14,
+    shadowColor: '#575757',
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 3,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  logoWrap: {
+    width: 56,
+    height: 56,
+    borderRadius: 12,
+    backgroundColor: '#F2F2F2',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+    overflow: 'hidden',
+  },
+  logo: {
+    width: 48,
+    height: 48,
+  },
+  headerText: {
+    flex: 1,
+  },
+  name: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: '#343232',
+    marginBottom: 4,
+  },
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    alignSelf: 'flex-start',
+    backgroundColor: '#E8F5EE',
+    paddingVertical: 2,
+    paddingHorizontal: 8,
+    borderRadius: 999,
+  },
+  badgeText: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#0A7E3F',
+    letterSpacing: 0.2,
+  },
+  tagline: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: '#343232',
+    marginBottom: 12,
+  },
+  benefits: {
+    marginBottom: 12,
+  },
+  benefitRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    marginBottom: 6,
+  },
+  benefitIcon: {
+    marginRight: 8,
+    marginTop: 1,
+  },
+  benefitText: {
+    flex: 1,
+    fontSize: 13,
+    lineHeight: 18,
+    color: '#575757',
+  },
+  promoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F8F9FA',
+    borderRadius: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    marginBottom: 12,
+    gap: 8,
+  },
+  promoLabel: {
+    fontSize: 13,
+    color: '#575757',
+  },
+  promoCode: {
+    flex: 1,
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#343232',
+    letterSpacing: 0.5,
+  },
+  cta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#000000',
+    borderRadius: 999,
+    paddingVertical: 12,
+    gap: 8,
+  },
+  ctaText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#FFFFFF',
+  },
+});

--- a/unify-front-end/components/learn/Resources/ResourcesView.tsx
+++ b/unify-front-end/components/learn/Resources/ResourcesView.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import { useAnalytics } from '@/utils/analytics';
+import { getCategoriesWithPartners } from '@/constants/Partners';
+import type { PartnerCategory } from '@/types/partner';
+import DisclosureCard from './DisclosureCard';
+import CategoryListItem from './CategoryListItem';
+import CategoryDetail from './CategoryDetail';
+
+/**
+ * Root view for the Resources tab inside Learn.
+ *
+ * Renders the category list by default. Tapping a category sets local
+ * state and renders the category detail (V1 keeps navigation in-screen
+ * rather than using router routes — see plan-eng-review for rationale).
+ */
+export default function ResourcesView() {
+  const [selectedCategory, setSelectedCategory] =
+    useState<PartnerCategory | null>(null);
+  const {
+    trackResourcesViewed,
+    trackResourcesCategoryOpened,
+  } = useAnalytics();
+
+  const categories = getCategoriesWithPartners();
+
+  // Fire view event once per mount.
+  useEffect(() => {
+    trackResourcesViewed('learn_tab');
+  }, [trackResourcesViewed]);
+
+  if (selectedCategory) {
+    return (
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <CategoryDetail
+          category={selectedCategory}
+          onBack={() => setSelectedCategory(null)}
+        />
+      </ScrollView>
+    );
+  }
+
+  return (
+    <ScrollView
+      contentContainerStyle={styles.scrollContent}
+      showsVerticalScrollIndicator={false}
+    >
+      <Text style={styles.title}>Trusted services for newcomers</Text>
+      <Text style={styles.subtitle}>
+        Curated partners for the essentials you need in your first months in
+        Canada.
+      </Text>
+
+      <DisclosureCard />
+
+      {categories.length === 0 ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyTitle}>We're vetting partners</Text>
+          <Text style={styles.emptyText}>
+            We're carefully selecting trusted partners for you. Check back soon.
+          </Text>
+        </View>
+      ) : (
+        categories.map(({ category, partnerCount }) => (
+          <CategoryListItem
+            key={category}
+            category={category}
+            partnerCount={partnerCount}
+            onPress={() => {
+              trackResourcesCategoryOpened(category, partnerCount);
+              setSelectedCategory(category);
+            }}
+          />
+        ))
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 100,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#000',
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 14,
+    lineHeight: 20,
+    color: '#575757',
+    marginBottom: 16,
+  },
+  empty: {
+    paddingVertical: 48,
+    alignItems: 'center',
+    backgroundColor: '#F8F9FA',
+    borderRadius: 12,
+    paddingHorizontal: 24,
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#343232',
+    marginBottom: 6,
+  },
+  emptyText: {
+    fontSize: 13,
+    color: '#575757',
+    textAlign: 'center',
+    lineHeight: 18,
+  },
+});

--- a/unify-front-end/components/learn/Resources/SegmentedControl.tsx
+++ b/unify-front-end/components/learn/Resources/SegmentedControl.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ViewStyle,
+} from 'react-native';
+
+type Props<T extends string> = {
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (value: T) => void;
+  style?: ViewStyle;
+};
+
+/**
+ * Two-or-more-option toggle. Used at the top of Learn to switch between
+ * Articles (existing CMS-driven content) and Resources (partner directory).
+ */
+export default function SegmentedControl<T extends string>({
+  value,
+  options,
+  onChange,
+  style,
+}: Props<T>) {
+  return (
+    <View style={[styles.container, style]}>
+      {options.map(option => {
+        const isActive = option.value === value;
+        return (
+          <TouchableOpacity
+            key={option.value}
+            activeOpacity={0.85}
+            onPress={() => onChange(option.value)}
+            style={[styles.segment, isActive && styles.segmentActive]}
+          >
+            <Text
+              style={[styles.label, isActive && styles.labelActive]}
+              numberOfLines={1}
+            >
+              {option.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    backgroundColor: '#F2F2F2',
+    borderRadius: 999,
+    padding: 4,
+    marginHorizontal: 16,
+    marginBottom: 8,
+  },
+  segment: {
+    flex: 1,
+    paddingVertical: 8,
+    borderRadius: 999,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  segmentActive: {
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#000',
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 1 },
+    elevation: 1,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#878787',
+  },
+  labelActive: {
+    color: '#000000',
+    fontWeight: '600',
+  },
+});

--- a/unify-front-end/constants/Partners.ts
+++ b/unify-front-end/constants/Partners.ts
@@ -1,0 +1,83 @@
+import type { Partner, PartnerCategory } from '@/types/partner';
+
+/**
+ * Partner directory. Hardcoded for V1.
+ *
+ * To add a partner: append to the array, set active: true, add a logo asset
+ * to assets/images/partners/, run EAS Update.
+ *
+ * To pause a partner: set active: false. Inactive partners are filtered out
+ * of all UI by getActivePartners.
+ *
+ * Migration note: when partner count reaches ~5 OR content edits ship more
+ * than weekly, migrate to Sanity. The Partner shape maps 1:1 to a Sanity
+ * doc type, so the swap is mechanical.
+ */
+export const PARTNERS: Partner[] = [
+  {
+    slug: 'unify-banking-partner',
+    name: '[Bank Partner]',
+    category: 'banking',
+    logo: require('@/assets/images/placeholderImg.png'),
+    tagline:
+      'Newcomer-friendly banking with no monthly fee for your first year.',
+    benefits: [
+      'No SIN required to open',
+      'Free Interac e-Transfers',
+      'Newcomer credit card eligible',
+    ],
+    promoCode: 'UNIFY-BANK',
+    partnerUrl: 'https://example.com/newcomer',
+    ctaLabel: 'Open Account',
+    displayOrder: 0,
+    active: true,
+    partnerSince: '2026-04-01',
+  },
+  {
+    slug: 'unify-immigration-partner',
+    name: '[Immigration Consultant]',
+    category: 'immigration',
+    logo: require('@/assets/images/placeholderImg.png'),
+    tagline:
+      'Licensed Canadian Immigration Consultants helping with PR, work permits, and citizenship.',
+    benefits: [
+      'CICC-registered consultants',
+      'Free initial consultation',
+      'Multilingual support',
+    ],
+    promoCode: 'UNIFY-IMM',
+    partnerUrl: 'https://example.com/consultation',
+    ctaLabel: 'Book Consultation',
+    displayOrder: 0,
+    active: true,
+    partnerSince: '2026-04-01',
+  },
+];
+
+/** Active partners only, sorted by displayOrder. */
+export const getActivePartners = (): Partner[] =>
+  PARTNERS.filter(p => p.active).sort(
+    (a, b) => a.displayOrder - b.displayOrder
+  );
+
+/** Active partners in a given category, sorted by displayOrder. */
+export const getPartnersByCategory = (category: PartnerCategory): Partner[] =>
+  getActivePartners().filter(p => p.category === category);
+
+/**
+ * Categories that have at least one active partner, with partner counts.
+ * Used to render the category list — empty categories are not shown.
+ */
+export const getCategoriesWithPartners = (): {
+  category: PartnerCategory;
+  partnerCount: number;
+}[] => {
+  const counts = new Map<PartnerCategory, number>();
+  for (const partner of getActivePartners()) {
+    counts.set(partner.category, (counts.get(partner.category) ?? 0) + 1);
+  }
+  return Array.from(counts.entries()).map(([category, partnerCount]) => ({
+    category,
+    partnerCount,
+  }));
+};

--- a/unify-front-end/types/partner.ts
+++ b/unify-front-end/types/partner.ts
@@ -1,0 +1,62 @@
+import type { ImageSourcePropType } from 'react-native';
+
+export type PartnerCategory =
+  | 'banking'
+  | 'telecom'
+  | 'insurance'
+  | 'housing'
+  | 'immigration'
+  | 'other';
+
+export const PARTNER_CATEGORY_LABELS: Record<PartnerCategory, string> = {
+  banking: 'Banking',
+  telecom: 'Phone & Internet',
+  insurance: 'Insurance',
+  housing: 'Housing',
+  immigration: 'Immigration',
+  other: 'Other',
+};
+
+export const PARTNER_CATEGORY_DESCRIPTIONS: Record<PartnerCategory, string> = {
+  banking: 'Open a Canadian bank account. Most newcomers do this in week 1.',
+  telecom: 'Phone plans and internet for newcomers.',
+  insurance: 'Health, auto, and tenant insurance.',
+  housing: 'Rentals, temporary housing, and neighbourhood resources.',
+  immigration: 'Licensed consultants for PR, work permits, and citizenship.',
+  other: 'Other services for newcomers.',
+};
+
+export const PARTNER_CATEGORY_ICONS: Record<PartnerCategory, string> = {
+  banking: 'bank-outline',
+  telecom: 'cellphone',
+  insurance: 'shield-outline',
+  housing: 'home-outline',
+  immigration: 'passport',
+  other: 'information-outline',
+};
+
+export interface Partner {
+  /** Unique slug used in UTM campaign param. e.g. 'unify-bankname' */
+  slug: string;
+  /** Display name shown to users */
+  name: string;
+  category: PartnerCategory;
+  /** Static asset, imported via require('@/assets/images/partners/foo.png') */
+  logo: ImageSourcePropType;
+  /** 1-line value prop */
+  tagline: string;
+  /** Up to 5 short bullet points */
+  benefits: string[];
+  /** Optional promo code, copyable */
+  promoCode?: string;
+  /** Bare partner URL — UTM params are appended at click time via buildPartnerUrl */
+  partnerUrl: string;
+  /** CTA button label, e.g. "Open Account", "Book Consultation" */
+  ctaLabel: string;
+  /** Lower numbers render first */
+  displayOrder: number;
+  /** Inactive partners are filtered out of all UI */
+  active: boolean;
+  /** ISO date the partnership started, for record-keeping */
+  partnerSince: string;
+}

--- a/unify-front-end/utils/analytics.ts
+++ b/unify-front-end/utils/analytics.ts
@@ -93,6 +93,14 @@ export const AnalyticsEvents = {
   // Daily Tips
   TIP_VIEWED: 'tip_viewed',
   TIP_TAPPED: 'tip_tapped',
+
+  // Resources (referral / monetization)
+  RESOURCES_VIEWED: 'resources_viewed',
+  RESOURCES_CATEGORY_OPENED: 'resources_category_opened',
+  RESOURCES_PARTNER_CARD_VIEWED: 'resources_partner_card_viewed',
+  RESOURCES_PARTNER_PROMO_COPIED: 'resources_partner_promo_copied',
+  RESOURCES_PARTNER_CTA_TAPPED: 'resources_partner_cta_tapped',
+  RESOURCES_PARTNER_CTA_FAILED: 'resources_partner_cta_failed',
 } as const;
 
 export type AnalyticsEventName =
@@ -538,6 +546,54 @@ export function useAnalytics() {
         posthog?.capture(AnalyticsEvents.TIP_TAPPED, {
           tip_id: tipId,
           category,
+        });
+      },
+
+      // Resources (referral / monetization)
+      trackResourcesViewed: (source: string) => {
+        posthog?.capture(AnalyticsEvents.RESOURCES_VIEWED, { source });
+      },
+      trackResourcesCategoryOpened: (
+        category: string,
+        partnerCount: number
+      ) => {
+        posthog?.capture(AnalyticsEvents.RESOURCES_CATEGORY_OPENED, {
+          category,
+          partner_count: partnerCount,
+        });
+      },
+      trackResourcesPartnerCardViewed: (
+        partnerSlug: string,
+        category: string,
+        position: number
+      ) => {
+        posthog?.capture(AnalyticsEvents.RESOURCES_PARTNER_CARD_VIEWED, {
+          partner_slug: partnerSlug,
+          category,
+          position,
+        });
+      },
+      trackResourcesPartnerPromoCopied: (partnerSlug: string) => {
+        posthog?.capture(AnalyticsEvents.RESOURCES_PARTNER_PROMO_COPIED, {
+          partner_slug: partnerSlug,
+        });
+      },
+      trackResourcesPartnerCtaTapped: (
+        partnerSlug: string,
+        category: string
+      ) => {
+        posthog?.capture(AnalyticsEvents.RESOURCES_PARTNER_CTA_TAPPED, {
+          partner_slug: partnerSlug,
+          category,
+        });
+      },
+      trackResourcesPartnerCtaFailed: (
+        partnerSlug: string,
+        errorType: string
+      ) => {
+        posthog?.capture(AnalyticsEvents.RESOURCES_PARTNER_CTA_FAILED, {
+          partner_slug: partnerSlug,
+          error_type: errorType,
         });
       },
 

--- a/unify-front-end/utils/partners.ts
+++ b/unify-front-end/utils/partners.ts
@@ -1,0 +1,32 @@
+import type { Partner } from '@/types/partner';
+
+/**
+ * Where the user came from when they tapped a partner CTA.
+ * Used as utm_medium so partner reporting can attribute by surface.
+ */
+export type PartnerCtaSource =
+  | 'learn_resources'
+  | 'companion_ai'
+  | 'checklist_link'
+  | 'home_card';
+
+/**
+ * Append Unify's UTM scheme to a partner's bare URL.
+ *
+ * Single source of truth: the partner record stores the bare URL only,
+ * and the tracked URL is derived at click time. This prevents the same
+ * UTM scheme from drifting across partner records and lets us A/B
+ * different sources (Learn vs. Companion vs. Checklist) without
+ * editing partner data.
+ */
+export function buildPartnerUrl(
+  partner: Partner,
+  source: PartnerCtaSource
+): string {
+  const url = new URL(partner.partnerUrl);
+  url.searchParams.set('utm_source', 'unify');
+  url.searchParams.set('utm_medium', source);
+  url.searchParams.set('utm_campaign', partner.slug);
+  url.searchParams.set('ref', 'unify');
+  return url.toString();
+}


### PR DESCRIPTION
## Summary

- Adds a new **Resources** view inside the Learn tab via a segmented control (`[Articles | Resources]`). Articles is the default; Resources shows a curated partner directory grouped by category.
- Ships V1 with **2 placeholder partners** (banking + immigration) hardcoded in `constants/Partners.ts`. Partner data swap is a one-file edit when real partner answers arrive. Migration to a CMS-managed source is deferred (see TODOS.md).
- Wires **6 new PostHog events** through the existing `useAnalytics` wrapper for full referral funnel attribution. Every CTA click goes through `buildPartnerUrl(partner, source)` for consistent UTM tagging.

This is the foundation for Unify's referral-based monetization motion. See the design doc and plan-eng-review for the full architecture rationale (links below).

## What's in the diff

| File | Purpose |
|------|---------|
| `types/partner.ts` | `Partner` type, `PartnerCategory` union, category labels/icons/descriptions |
| `constants/Partners.ts` | `PARTNERS` array + `getActivePartners`, `getPartnersByCategory`, `getCategoriesWithPartners` helpers |
| `utils/partners.ts` | `buildPartnerUrl(partner, source)` — single source of truth for the UTM scheme |
| `utils/analytics.ts` | 6 new `RESOURCES_*` events with typed track methods |
| `components/learn/Resources/` | 6 new components (ResourcesView, CategoryListItem, CategoryDetail, PartnerCard, DisclosureCard, SegmentedControl) |
| `app/(tabs)/Learn/index.tsx` | Segmented control + view-state-driven conditional render |
| `TODOS.md` | 3 new P2 items from eng review |

**Total:** 981 insertions, 12 files. ~9 new files + 3 modified.

## Trust UX

- Persistent disclosure card on every Resources view explains the referral relationship up front.
- Every partner card shows a "Unify Partner" badge.
- All commercial content is contained to Resources view; community surfaces (Home, Gather, Companion) are unaffected.

## V1 trade-offs (intentional)

- **Hardcoded partner data, not Sanity.** YAGNI for 2 partners. Migration trigger documented in `constants/Partners.ts` header.
- **No automated tests.** Manual QA only for V1 per design decision. Component test infrastructure tracked as a P2 TODO.
- **Placeholder logos** until partner-provided assets arrive.
- **External browser opens** via `Linking.openURL` (matches existing project pattern in `news-detail.tsx`, `tip-detail.tsx`, `event-detail.tsx`). Failure path: copy URL to clipboard + toast + `resources_partner_cta_failed` event.

## Test plan

Automated coverage was deferred per design decision. Use the manual QA checklist below before merging:

- [ ] **Articles default:** Open Learn tab — Articles view renders, Continue Learning + module grid behave identically to pre-change.
- [ ] **Toggle works:** Tap "Resources" — Articles content hides, Resources content shows. Tap "Articles" again — back to Articles. Re-enter Learn from another tab — defaults to Articles.
- [ ] **Categories render:** Both Banking and Immigration categories appear with correct partner counts. Disclosure card visible.
- [ ] **Category detail:** Tap Banking — see partner card with logo, name, "Unify Partner" badge, tagline, benefits, promo code, CTA. Back arrow returns to category list.
- [ ] **CTA opens external browser:** Tap "Open Account" — device's external browser opens. URL has `utm_source=unify`, `utm_medium=learn_resources`, `utm_campaign={partner_slug}`, `ref=unify`.
- [ ] **Promo copy:** Tap promo code copy button — code is on clipboard, alert confirms.
- [ ] **PostHog events fire:** Verify in PostHog dashboard — `resources_viewed`, `resources_category_opened`, `resources_partner_card_viewed`, `resources_partner_cta_tapped`, `resources_partner_promo_copied` events appear with correct properties.
- [ ] **iOS + Android:** Tested on both platforms (latest + minimum supported).
- [ ] **Long content:** 30+ char partner name + Punjabi/Mandarin tagline render without overflow.
- [ ] **Missing promo code:** Set `promoCode: undefined` on a test partner — copy row hides cleanly.
- [ ] **Inactive partner:** Set `active: false` on a partner — does not appear in the directory.

## Follow-ups (not blocking this PR)

Three TODOs added to `TODOS.md` (P2):
1. Component test infrastructure (RTL setup) for future features.
2. i18n extraction for Resources copy when multi-language support lands.
3. Intersection-based view tracking for partner cards once partner count exceeds ~5 per category.

## Out of scope (deliberate)

- **Real partner data.** Awaiting answers from both signed partners on exclusivity, co-branding, landing page format, CPA terms, and privacy requirements before swapping placeholder values.
- **Sanity migration.** Deferred until partner #5+ or until content edits ship more than weekly.
- **Companion AI partner suggestions** and **Checklist deep-links** to Resources. Future surfaces; keeps V1 narrow.
- **6th bottom tab.** Embedded in Learn for V1; promotion gated on 30-day MAU view rate ≥20%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Resources" view to the Learn tab, allowing users to browse trusted partner services organized by category.
  * Added partner cards displaying partner information, promotional codes, and action buttons to visit partner sites.
  * Added disclosure messaging about partnerships.
  * Added segmented control to toggle between "Articles" and "Resources" views in Learn tab.

* **Chores**
  * Added future improvement TODOs for testing infrastructure, internationalization readiness, and analytics accuracy enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->