### PR TITLE
feat(companion): dynamic personalized chips that refresh on tap

### DIFF
--- a/unify-front-end/.gitignore
+++ b/unify-front-end/.gitignore
@@ -30,3 +30,6 @@ amplifyconfiguration*
 .env
 .env.local
 .env.*.local
+
+# Un-ignore __tests__ (overrides root .gitignore which ignores it globally)
+!__tests__/

--- a/unify-front-end/__tests__/companion/companionStarterHistory.test.ts
+++ b/unify-front-end/__tests__/companion/companionStarterHistory.test.ts
@@ -50,4 +50,26 @@ describe('companionStarterHistory', () => {
     const ids = await getSeenStarterIds();
     expect(ids.size).toBe(0);
   });
+
+  it('serializes concurrent marks so no updates are lost', async () => {
+    await Promise.all([
+      markStarterSeen('a'),
+      markStarterSeen('b'),
+      markStarterSeen('c'),
+      markStarterSeen('d'),
+      markStarterSeen('e'),
+    ]);
+    const ids = await getSeenStarterIds();
+    expect(Array.from(ids).sort()).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('orders a clear after preceding concurrent marks', async () => {
+    await Promise.all([
+      markStarterSeen('a'),
+      markStarterSeen('b'),
+      clearSeenStarterIds(),
+    ]);
+    const ids = await getSeenStarterIds();
+    expect(ids.size).toBe(0);
+  });
 });

--- a/unify-front-end/__tests__/companion/companionStarterHistory.test.ts
+++ b/unify-front-end/__tests__/companion/companionStarterHistory.test.ts
@@ -1,0 +1,53 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  getSeenStarterIds,
+  markStarterSeen,
+  clearSeenStarterIds,
+  COMPANION_STARTER_HISTORY_KEY,
+} from '@/utils/companionStarterHistory';
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe('companionStarterHistory', () => {
+  it('returns an empty set when nothing is stored', async () => {
+    const ids = await getSeenStarterIds();
+    expect(ids.size).toBe(0);
+  });
+
+  it('persists a marked starter id', async () => {
+    await markStarterSeen('persona_city');
+    const ids = await getSeenStarterIds();
+    expect(ids.has('persona_city')).toBe(true);
+  });
+
+  it('deduplicates repeated marks of the same id', async () => {
+    await markStarterSeen('persona_city');
+    await markStarterSeen('persona_city');
+    const ids = await getSeenStarterIds();
+    expect(ids.size).toBe(1);
+  });
+
+  it('preserves multiple distinct ids across marks', async () => {
+    await markStarterSeen('a');
+    await markStarterSeen('b');
+    await markStarterSeen('c');
+    const ids = await getSeenStarterIds();
+    expect(Array.from(ids).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('clears all stored ids', async () => {
+    await markStarterSeen('a');
+    await markStarterSeen('b');
+    await clearSeenStarterIds();
+    const ids = await getSeenStarterIds();
+    expect(ids.size).toBe(0);
+  });
+
+  it('returns an empty set when AsyncStorage contains malformed JSON', async () => {
+    await AsyncStorage.setItem(COMPANION_STARTER_HISTORY_KEY, 'not-json');
+    const ids = await getSeenStarterIds();
+    expect(ids.size).toBe(0);
+  });
+});

--- a/unify-front-end/__tests__/companion/companionTemplates.test.ts
+++ b/unify-front-end/__tests__/companion/companionTemplates.test.ts
@@ -1,0 +1,112 @@
+import {
+  buildPool,
+  OnboardingProfile,
+} from '@/supabase/functions/_shared/companionTemplates';
+
+const emptyProfile: OnboardingProfile = {
+  persona: null, city: null, province: null, arrival_date: null,
+  stage: null, goals: [], learning_interests: [], hobbies: [],
+};
+
+function profile(p: Partial<OnboardingProfile>): OnboardingProfile {
+  return { ...emptyProfile, ...p };
+}
+
+describe('buildPool', () => {
+  it('returns an empty pool for a profile with no signals', () => {
+    expect(buildPool(emptyProfile)).toEqual([]);
+  });
+
+  it('includes a persona+city template when both are set', () => {
+    const out = buildPool(
+      profile({ persona: 'skilled_worker', city: 'Vancouver' })
+    );
+    const match = out.find(s => s.id === 'persona_city');
+    expect(match).toBeDefined();
+    expect(match!.category).toBe('Vancouver');
+    expect(match!.prompt).toContain('skilled worker');
+    expect(match!.prompt).toContain('Vancouver');
+  });
+
+  it('includes a persona-only template when city is missing', () => {
+    const out = buildPool(profile({ persona: 'refugee' }));
+    expect(out.find(s => s.id === 'persona_only')).toBeDefined();
+  });
+
+  it('includes a recent-arrival template when arrival_date is within 6 months', () => {
+    const recent = new Date();
+    recent.setMonth(recent.getMonth() - 2);
+    const out = buildPool(
+      profile({ arrival_date: recent.toISOString().slice(0, 10) })
+    );
+    expect(out.find(s => s.id === 'arrival_recent')).toBeDefined();
+  });
+
+  it('includes a future-arrival template when arrival_date is in the future', () => {
+    const future = new Date();
+    future.setMonth(future.getMonth() + 3);
+    const out = buildPool(
+      profile({ arrival_date: future.toISOString().slice(0, 10) })
+    );
+    expect(out.find(s => s.id === 'arrival_future')).toBeDefined();
+  });
+
+  it('emits one template per learning interest', () => {
+    const out = buildPool(
+      profile({ learning_interests: ['healthcare', 'housing', 'pr_immigration'] })
+    );
+    expect(out.find(s => s.id === 'interest_healthcare')).toBeDefined();
+    expect(out.find(s => s.id === 'interest_housing')).toBeDefined();
+    expect(out.find(s => s.id === 'interest_pr_immigration')).toBeDefined();
+  });
+
+  it('emits one template per hobby × city when both available', () => {
+    const out = buildPool(
+      profile({ city: 'Toronto', hobbies: ['fitness', 'food_cooking'] })
+    );
+    expect(out.find(s => s.id === 'hobby_fitness_city')).toBeDefined();
+    expect(out.find(s => s.id === 'hobby_food_cooking_city')).toBeDefined();
+  });
+
+  it('does not emit hobby templates when city is missing', () => {
+    const out = buildPool(profile({ hobbies: ['fitness'] }));
+    expect(out.find(s => s.id?.startsWith('hobby_'))).toBeUndefined();
+  });
+
+  it('sorts pool by priority descending', () => {
+    const out = buildPool(
+      profile({
+        persona: 'skilled_worker',
+        city: 'Vancouver',
+        learning_interests: ['employment'],
+      })
+    );
+    for (let i = 1; i < out.length; i++) {
+      expect(out[i - 1].priority).toBeGreaterThanOrEqual(out[i].priority);
+    }
+  });
+
+  it('caps the pool at 30 entries', () => {
+    const fat = profile({
+      persona: 'skilled_worker',
+      city: 'Toronto',
+      province: 'ON',
+      arrival_date: '2026-04-20',
+      stage: '3',
+      goals: ['learn_something', 'build_community', 'quick_answers'],
+      learning_interests: ['documents', 'employment', 'finance', 'housing',
+                           'pr_immigration', 'healthcare', 'family_kids', 'transit'],
+      hobbies: ['career_growth', 'exploring_canada', 'wellness', 'technology',
+                'music', 'fitness', 'personal_finance', 'family_parenting',
+                'education', 'food_cooking', 'movies'],
+    });
+    expect(buildPool(fat).length).toBeLessThanOrEqual(30);
+  });
+
+  it('produces stable ids across calls with the same profile', () => {
+    const p = profile({ persona: 'international_student', city: 'Vancouver' });
+    const a = buildPool(p).map(s => s.id);
+    const b = buildPool(p).map(s => s.id);
+    expect(a).toEqual(b);
+  });
+});

--- a/unify-front-end/components/companion/StarterPrompts.tsx
+++ b/unify-front-end/components/companion/StarterPrompts.tsx
@@ -165,35 +165,50 @@ export const StarterPrompts: React.FC<StarterPromptsProps> = ({
   }, [pool]);
 
   const handlePersonalizedPress = useCallback(
-    async (starter: PersonalizedStarter, slotIndex: number) => {
+    (starter: PersonalizedStarter, slotIndex: number) => {
       onPromptSelect(starter.prompt);
 
-      // Persist; fire-and-forget.
+      // Persist; fire-and-forget. Concurrent calls are safe — markStarterSeen
+      // serializes its own read-modify-write internally.
       void markStarterSeen(starter.id);
       seenIdsRef.current.add(starter.id);
 
-      const displayedIds = new Set(displayed.map(s => s.id));
-      let next = pickReplacement(pool, displayedIds, seenIdsRef.current, starter.id);
-
-      // If pool is exhausted relative to seen, clear and try once more.
-      if (!next) {
-        const fallback = pool.find(s => !displayedIds.has(s.id) && s.id !== starter.id);
-        if (fallback) {
-          await clearSeenStarterIds();
-          seenIdsRef.current = new Set();
-          next = fallback;
-        }
-      }
-
-      if (!next) return; // pool too small to swap; leave the chip in place.
-
+      // Compute the replacement against the COMMITTED current displayed state
+      // inside the updater. Reading `displayed` from a stale closure here would
+      // race when the user taps two chips in rapid succession — both handlers
+      // would see the same pre-tap state and could pick the same replacement,
+      // leaving the same chip in two slots after both updates land.
       setDisplayed(current => {
+        const displayedIds = new Set(current.map(s => s.id));
+        let next = pickReplacement(
+          pool,
+          displayedIds,
+          seenIdsRef.current,
+          starter.id
+        );
+
+        if (!next) {
+          const fallback = pool.find(
+            s => !displayedIds.has(s.id) && s.id !== starter.id
+          );
+          if (fallback) {
+            // Pool exhausted relative to seen — reset history. Both side
+            // effects are idempotent so they remain safe under React strict-
+            // mode double invocation of the updater.
+            seenIdsRef.current = new Set();
+            void clearSeenStarterIds();
+            next = fallback;
+          }
+        }
+
+        if (!next) return current; // pool too small to swap; leave chip in place.
+
         const copy = [...current];
-        copy[slotIndex] = next!;
+        copy[slotIndex] = next;
         return copy;
       });
     },
-    [displayed, pool, onPromptSelect]
+    [pool, onPromptSelect]
   );
 
   return (

--- a/unify-front-end/components/companion/StarterPrompts.tsx
+++ b/unify-front-end/components/companion/StarterPrompts.tsx
@@ -96,12 +96,12 @@ function pickInitial(
   seen: Set<string>
 ): PersonalizedStarter[] {
   if (pool.length === 0) return [];
-  const unseen = pool.filter(s => !seen.has(s.id));
-  if (unseen.length >= VISIBLE_SLOTS) return unseen.slice(0, VISIBLE_SLOTS);
-  // Pool smaller than VISIBLE_SLOTS — render whatever is available.
-  // (When pool >= VISIBLE_SLOTS but unseen < VISIBLE_SLOTS, the caller
-  // clears seen storage before invoking this, so we never land here in that case.)
-  return pool.slice(0, Math.min(pool.length, VISIBLE_SLOTS));
+  // Render up to VISIBLE_SLOTS unseen chips. When fewer unseen remain than
+  // slots, the personalized section shrinks gracefully — the user sees a 1-
+  // or 2-chip section signalling they've explored most of their personalized
+  // prompts. The mount-time effect resets `seen` only when zero unseen remain,
+  // so we never need to fall back to seen entries here.
+  return pool.filter(s => !seen.has(s.id)).slice(0, VISIBLE_SLOTS);
 }
 
 function pickReplacement(
@@ -146,8 +146,12 @@ export const StarterPrompts: React.FC<StarterPromptsProps> = ({
     let cancelled = false;
     (async () => {
       let seen = await getSeenStarterIds();
-      const unseen = pool.filter(s => !seen.has(s.id));
-      if (unseen.length < VISIBLE_SLOTS && pool.length >= VISIBLE_SLOTS) {
+      // Reset seen history only when the user has tapped through the entire
+      // pool — otherwise a partial reset would resurface chips they tapped
+      // recently. When unseen is between 1 and VISIBLE_SLOTS-1 we render
+      // fewer chips rather than padding the slots with already-tapped ones.
+      const hasUnseen = pool.some(s => !seen.has(s.id));
+      if (!hasUnseen) {
         await clearSeenStarterIds();
         seen = new Set();
       }

--- a/unify-front-end/components/companion/StarterPrompts.tsx
+++ b/unify-front-end/components/companion/StarterPrompts.tsx
@@ -200,26 +200,27 @@ export const StarterPrompts: React.FC<StarterPromptsProps> = ({
         contentContainerStyle={styles.scrollContent}
       >
         {displayed.map((starter, index) => (
-          <Animated.View
-            key={starter.id}
-            entering={FadeIn.duration(200)}
-            exiting={FadeOut.duration(150)}
-          >
-            <TouchableOpacity
-              style={[styles.card, styles.cardPersonalized]}
-              onPress={() => handlePersonalizedPress(starter, index)}
-              activeOpacity={0.8}
+          <View key={starter.id}>
+            <Animated.View
+              entering={FadeIn.duration(200)}
+              exiting={FadeOut.duration(150)}
             >
-              <View style={styles.cardHeader}>
-                <View style={[styles.iconBadge, { backgroundColor: starter.iconBackground }]}>
-                  <Feather name={starter.iconName as keyof typeof Feather.glyphMap} size={16} color={Theme.white} />
+              <TouchableOpacity
+                style={[styles.card, styles.cardPersonalized]}
+                onPress={() => handlePersonalizedPress(starter, index)}
+                activeOpacity={0.8}
+              >
+                <View style={styles.cardHeader}>
+                  <View style={[styles.iconBadge, { backgroundColor: starter.iconBackground }]}>
+                    <Feather name={starter.iconName as keyof typeof Feather.glyphMap} size={16} color={Theme.white} />
+                  </View>
+                  <Text style={styles.cardLabel} numberOfLines={1}>{starter.category}</Text>
+                  <Feather name='chevron-right' size={16} color={Theme.textInactiveTab} />
                 </View>
-                <Text style={styles.cardLabel} numberOfLines={1}>{starter.category}</Text>
-                <Feather name='chevron-right' size={16} color={Theme.textInactiveTab} />
-              </View>
-              <Text style={styles.cardDescription} numberOfLines={3}>{starter.prompt}</Text>
-            </TouchableOpacity>
-          </Animated.View>
+                <Text style={styles.cardDescription} numberOfLines={3}>{starter.prompt}</Text>
+              </TouchableOpacity>
+            </Animated.View>
+          </View>
         ))}
 
         {[...MODE_CARDS, ...topicStarters].map(card => (

--- a/unify-front-end/components/companion/StarterPrompts.tsx
+++ b/unify-front-end/components/companion/StarterPrompts.tsx
@@ -1,3 +1,4 @@
+// components/companion/StarterPrompts.tsx
 import React, { useMemo } from 'react';
 import {
   View,
@@ -8,13 +9,14 @@ import {
 } from 'react-native';
 import { Feather } from '@expo/vector-icons';
 import { Theme } from '@/constants/Theme';
+import type { PersonalizedStarter } from '@/hooks/companion/usePersonalizedStarters';
 
 interface StarterPromptsProps {
   onPromptSelect: (prompt: string, mode?: string) => void;
-  personalizedStarters?: string[];
+  personalizedStarters?: PersonalizedStarter[];
 }
 
-interface StarterCard {
+interface StaticCard {
   id: string;
   label: string;
   prompt: string;
@@ -24,178 +26,68 @@ interface StarterCard {
   description: string;
 }
 
-// Mode-based cards (Fact Check, Form Help)
-const MODE_CARDS: StarterCard[] = [
-  {
-    id: 'fact_check',
-    label: 'Fact Check',
-    prompt: 'I heard that ',
-    mode: 'fact_check',
-    iconName: 'search',
-    iconBackground: '#4F7BCB',
-    description: "Verify info you've heard or read.",
-  },
-  {
-    id: 'form_help',
-    label: 'Form Help',
-    prompt: '',
-    mode: 'form_help',
-    iconName: 'file-text',
-    iconBackground: '#F0A04B',
-    description: 'Step-by-step guidance on any form.',
-  },
+const MODE_CARDS: StaticCard[] = [
+  { id: 'fact_check', label: 'Fact Check', prompt: 'I heard that ', mode: 'fact_check',
+    iconName: 'search', iconBackground: '#4F7BCB',
+    description: "Verify info you've heard or read." },
+  { id: 'form_help', label: 'Form Help', prompt: '', mode: 'form_help',
+    iconName: 'file-text', iconBackground: '#F0A04B',
+    description: 'Step-by-step guidance on any form.' },
 ];
 
-// Topic-based starter prompts organized by immigration category
-const TOPIC_STARTERS: StarterCard[] = [
-  {
-    id: 'ee_eligibility',
-    label: 'Express Entry',
-    prompt: 'Am I eligible for Express Entry? What are the requirements?',
-    iconName: 'award',
-    iconBackground: '#5C6BC0',
-    description: 'Check Express Entry eligibility.',
-  },
-  {
-    id: 'ee_crs',
-    label: 'CRS Score',
-    prompt: 'How is the CRS score calculated for Express Entry?',
-    iconName: 'bar-chart-2',
-    iconBackground: '#5C6BC0',
-    description: 'Understand CRS point breakdown.',
-  },
-  {
-    id: 'ee_rounds',
-    label: 'Recent Draws',
-    prompt: 'What were the most recent Express Entry draw scores?',
-    iconName: 'trending-up',
-    iconBackground: '#5C6BC0',
-    description: 'Latest invitation round details.',
-  },
-  {
-    id: 'sp_apply',
-    label: 'Study Permit',
-    prompt: 'How do I apply for a Canadian study permit?',
-    iconName: 'book-open',
-    iconBackground: '#26A69A',
-    description: 'Study permit application steps.',
-  },
-  {
-    id: 'sp_pgwp',
-    label: 'After Graduation',
-    prompt: 'How do I get a post-graduation work permit (PGWP)?',
-    iconName: 'briefcase',
-    iconBackground: '#26A69A',
-    description: 'PGWP eligibility and process.',
-  },
-  {
-    id: 'wp_types',
-    label: 'Work Permits',
-    prompt: 'What types of work permits are available in Canada?',
-    iconName: 'tool',
-    iconBackground: '#EF5350',
-    description: 'Compare open vs employer-specific.',
-  },
-  {
-    id: 'wp_lmia',
-    label: 'LMIA Process',
-    prompt: 'What is an LMIA and when do I need one?',
-    iconName: 'clipboard',
-    iconBackground: '#EF5350',
-    description: 'Labour market impact assessment.',
-  },
-  {
-    id: 'cit_eligibility',
-    label: 'Citizenship',
-    prompt: 'What are the requirements to become a Canadian citizen?',
-    iconName: 'flag',
-    iconBackground: '#E3A0C9',
-    description: 'Citizenship eligibility check.',
-  },
-  {
-    id: 'cit_test',
-    label: 'Citizenship Test',
-    prompt: 'What should I study for the Canadian citizenship test?',
-    iconName: 'edit-3',
-    iconBackground: '#E3A0C9',
-    description: 'Test prep and study guide.',
-  },
-  {
-    id: 'settle_health',
-    label: 'Healthcare',
-    prompt: 'How does healthcare work for newcomers to Canada?',
-    iconName: 'heart',
-    iconBackground: '#66BB6A',
-    description: 'Provincial health coverage info.',
-  },
-  {
-    id: 'settle_services',
-    label: 'Newcomer Help',
-    prompt: 'What free settlement services are available for newcomers?',
-    iconName: 'users',
-    iconBackground: '#66BB6A',
-    description: 'Free support for new arrivals.',
-  },
+const TOPIC_STARTERS: StaticCard[] = [
+  { id: 'ee_eligibility', label: 'Express Entry', prompt: 'Am I eligible for Express Entry? What are the requirements?',
+    iconName: 'award', iconBackground: '#5C6BC0', description: 'Check Express Entry eligibility.' },
+  { id: 'ee_crs', label: 'CRS Score', prompt: 'How is the CRS score calculated for Express Entry?',
+    iconName: 'bar-chart-2', iconBackground: '#5C6BC0', description: 'Understand CRS point breakdown.' },
+  { id: 'ee_rounds', label: 'Recent Draws', prompt: 'What were the most recent Express Entry draw scores?',
+    iconName: 'trending-up', iconBackground: '#5C6BC0', description: 'Latest invitation round details.' },
+  { id: 'sp_apply', label: 'Study Permit', prompt: 'How do I apply for a Canadian study permit?',
+    iconName: 'book-open', iconBackground: '#26A69A', description: 'Study permit application steps.' },
+  { id: 'sp_pgwp', label: 'After Graduation', prompt: 'How do I get a post-graduation work permit (PGWP)?',
+    iconName: 'briefcase', iconBackground: '#26A69A', description: 'PGWP eligibility and process.' },
+  { id: 'wp_types', label: 'Work Permits', prompt: 'What types of work permits are available in Canada?',
+    iconName: 'tool', iconBackground: '#EF5350', description: 'Compare open vs employer-specific.' },
+  { id: 'wp_lmia', label: 'LMIA Process', prompt: 'What is an LMIA and when do I need one?',
+    iconName: 'clipboard', iconBackground: '#EF5350', description: 'Labour market impact assessment.' },
+  { id: 'cit_eligibility', label: 'Citizenship', prompt: 'What are the requirements to become a Canadian citizen?',
+    iconName: 'flag', iconBackground: '#E3A0C9', description: 'Citizenship eligibility check.' },
+  { id: 'cit_test', label: 'Citizenship Test', prompt: 'What should I study for the Canadian citizenship test?',
+    iconName: 'edit-3', iconBackground: '#E3A0C9', description: 'Test prep and study guide.' },
+  { id: 'settle_health', label: 'Healthcare', prompt: 'How does healthcare work for newcomers to Canada?',
+    iconName: 'heart', iconBackground: '#66BB6A', description: 'Provincial health coverage info.' },
+  { id: 'settle_services', label: 'Newcomer Help', prompt: 'What free settlement services are available for newcomers?',
+    iconName: 'users', iconBackground: '#66BB6A', description: 'Free support for new arrivals.' },
 ];
 
-/**
- * Selects a random subset of topic starters, ensuring variety across categories.
- * Returns 3 topic cards from different icon backgrounds (categories).
- */
-const selectRandomStarters = (): StarterCard[] => {
-  const categories = new Map<string, StarterCard[]>();
+const selectRandomTopicStarters = (): StaticCard[] => {
+  const categories = new Map<string, StaticCard[]>();
   TOPIC_STARTERS.forEach(card => {
     const existing = categories.get(card.iconBackground) || [];
     existing.push(card);
     categories.set(card.iconBackground, existing);
   });
 
-  const selected: StarterCard[] = [];
+  const selected: StaticCard[] = [];
   const categoryKeys = Array.from(categories.keys());
-
-  // Shuffle categories
   for (let i = categoryKeys.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
     [categoryKeys[i], categoryKeys[j]] = [categoryKeys[j], categoryKeys[i]];
   }
-
-  // Pick one random card from each category until we have 3
   for (const key of categoryKeys) {
     if (selected.length >= 3) break;
     const cards = categories.get(key)!;
-    const randomCard = cards[Math.floor(Math.random() * cards.length)];
-    selected.push(randomCard);
+    selected.push(cards[Math.floor(Math.random() * cards.length)]);
   }
-
   return selected;
 };
-
-/**
- * Convert personalized starter strings into StarterCard format so they
- * render identically to the other cards in a single horizontal scroll.
- */
-const PERSONALIZED_ICON_BG = '#7C5CBF';
-
-const toPersonalizedCard = (prompt: string, index: number): StarterCard => ({
-  id: `personalized-${index}`,
-  label: 'For You',
-  prompt,
-  iconName: 'user',
-  iconBackground: PERSONALIZED_ICON_BG,
-  description: prompt,
-});
 
 export const StarterPrompts: React.FC<StarterPromptsProps> = ({
   onPromptSelect,
   personalizedStarters,
 }) => {
-  const topicStarters = useMemo(() => selectRandomStarters(), []);
-
-  // Unified card list: personalized first → mode cards → topic starters
-  const allCards = useMemo(() => {
-    const personalized = (personalizedStarters ?? []).map(toPersonalizedCard);
-    return [...personalized, ...MODE_CARDS, ...topicStarters];
-  }, [personalizedStarters, topicStarters]);
+  const topicStarters = useMemo(() => selectRandomTopicStarters(), []);
+  const personalized = personalizedStarters ?? [];
 
   return (
     <View style={styles.container}>
@@ -204,90 +96,60 @@ export const StarterPrompts: React.FC<StarterPromptsProps> = ({
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.scrollContent}
       >
-        {allCards.map(card => {
-          const isPersonalized = card.id.startsWith('personalized-');
-          return (
-            <TouchableOpacity
-              key={card.id}
-              style={[styles.card, isPersonalized && styles.cardPersonalized]}
-              onPress={() => onPromptSelect(card.prompt, card.mode)}
-              activeOpacity={0.8}
-            >
-              <View style={styles.cardHeader}>
-                <View
-                  style={[
-                    styles.iconBadge,
-                    { backgroundColor: card.iconBackground },
-                  ]}
-                >
-                  <Feather name={card.iconName} size={16} color={Theme.white} />
-                </View>
-                <Text style={styles.cardLabel}>{card.label}</Text>
-                <Feather
-                  name='chevron-right'
-                  size={16}
-                  color={Theme.textInactiveTab}
-                />
+        {personalized.map(starter => (
+          <TouchableOpacity
+            key={starter.id}
+            style={[styles.card, styles.cardPersonalized]}
+            onPress={() => onPromptSelect(starter.prompt)}
+            activeOpacity={0.8}
+          >
+            <View style={styles.cardHeader}>
+              <View style={[styles.iconBadge, { backgroundColor: starter.iconBackground }]}>
+                <Feather name={starter.iconName as keyof typeof Feather.glyphMap} size={16} color={Theme.white} />
               </View>
-              <Text
-                style={styles.cardDescription}
-                numberOfLines={isPersonalized ? 3 : 2}
-              >
-                {card.description}
-              </Text>
-            </TouchableOpacity>
-          );
-        })}
+              <Text style={styles.cardLabel} numberOfLines={1}>{starter.category}</Text>
+              <Feather name='chevron-right' size={16} color={Theme.textInactiveTab} />
+            </View>
+            <Text style={styles.cardDescription} numberOfLines={3}>{starter.prompt}</Text>
+          </TouchableOpacity>
+        ))}
+
+        {[...MODE_CARDS, ...topicStarters].map(card => (
+          <TouchableOpacity
+            key={card.id}
+            style={styles.card}
+            onPress={() => onPromptSelect(card.prompt, card.mode)}
+            activeOpacity={0.8}
+          >
+            <View style={styles.cardHeader}>
+              <View style={[styles.iconBadge, { backgroundColor: card.iconBackground }]}>
+                <Feather name={card.iconName} size={16} color={Theme.white} />
+              </View>
+              <Text style={styles.cardLabel}>{card.label}</Text>
+              <Feather name='chevron-right' size={16} color={Theme.textInactiveTab} />
+            </View>
+            <Text style={styles.cardDescription} numberOfLines={2}>{card.description}</Text>
+          </TouchableOpacity>
+        ))}
       </ScrollView>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
-  container: {
-    paddingTop: 10,
-    paddingBottom: 12,
-    backgroundColor: Theme.white,
-  },
-  scrollContent: {
-    paddingHorizontal: 20,
-    paddingRight: 32,
-  },
+  container: { paddingTop: 10, paddingBottom: 12, backgroundColor: Theme.white },
+  scrollContent: { paddingHorizontal: 20, paddingRight: 32 },
   card: {
-    width: 170,
-    minHeight: 108,
-    backgroundColor: Theme.white,
-    borderRadius: 16,
-    borderWidth: 1,
-    borderColor: '#e0e0e0',
-    padding: 12,
-    marginRight: 12,
+    width: 170, minHeight: 108, backgroundColor: Theme.white,
+    borderRadius: 16, borderWidth: 1, borderColor: '#e0e0e0',
+    padding: 12, marginRight: 12,
   },
-  cardPersonalized: {
-    width: 210,
-  },
-  cardHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
+  cardPersonalized: { width: 210 },
+  cardHeader: { flexDirection: 'row', alignItems: 'center' },
   iconBadge: {
-    width: 26,
-    height: 26,
-    borderRadius: 8,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginRight: 8,
+    width: 26, height: 26, borderRadius: 8,
+    justifyContent: 'center', alignItems: 'center', marginRight: 8,
   },
-  cardLabel: {
-    flex: 1,
-    fontSize: 15,
-    fontWeight: '600',
-    color: Theme.black,
-  },
-  cardDescription: {
-    marginTop: 10,
-    fontSize: 12,
-    color: Theme.textInput,
-    lineHeight: 16,
-  },
+  cardLabel: { flex: 1, fontSize: 15, fontWeight: '600', color: Theme.black },
+  cardDescription: { marginTop: 10, fontSize: 12, color: Theme.textInput, lineHeight: 16 },
 });

--- a/unify-front-end/components/companion/StarterPrompts.tsx
+++ b/unify-front-end/components/companion/StarterPrompts.tsx
@@ -1,5 +1,5 @@
 // components/companion/StarterPrompts.tsx
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react';
 import {
   View,
   Text,
@@ -7,9 +7,15 @@ import {
   StyleSheet,
   ScrollView,
 } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { Feather } from '@expo/vector-icons';
 import { Theme } from '@/constants/Theme';
 import type { PersonalizedStarter } from '@/hooks/companion/usePersonalizedStarters';
+import {
+  getSeenStarterIds,
+  markStarterSeen,
+  clearSeenStarterIds,
+} from '@/utils/companionStarterHistory';
 
 interface StarterPromptsProps {
   onPromptSelect: (prompt: string, mode?: string) => void;
@@ -82,12 +88,109 @@ const selectRandomTopicStarters = (): StaticCard[] => {
   return selected;
 };
 
+const EMPTY_POOL: PersonalizedStarter[] = [];
+const VISIBLE_SLOTS = 3;
+
+function pickInitial(
+  pool: PersonalizedStarter[],
+  seen: Set<string>
+): PersonalizedStarter[] {
+  if (pool.length === 0) return [];
+  const unseen = pool.filter(s => !seen.has(s.id));
+  if (unseen.length >= VISIBLE_SLOTS) return unseen.slice(0, VISIBLE_SLOTS);
+  // Pool smaller than VISIBLE_SLOTS — render whatever is available.
+  // (When pool >= VISIBLE_SLOTS but unseen < VISIBLE_SLOTS, the caller
+  // clears seen storage before invoking this, so we never land here in that case.)
+  return pool.slice(0, Math.min(pool.length, VISIBLE_SLOTS));
+}
+
+function pickReplacement(
+  pool: PersonalizedStarter[],
+  displayedIds: Set<string>,
+  seen: Set<string>,
+  tappedId: string
+): PersonalizedStarter | null {
+  if (pool.length === 0) return null;
+  const isCandidate = (s: PersonalizedStarter) =>
+    !displayedIds.has(s.id) && !seen.has(s.id) && s.id !== tappedId;
+
+  let next = pool.find(isCandidate);
+  if (next) return next;
+
+  // Exhausted relative to seen — caller should clear seen storage; here pick from pool excluding displayed + tapped.
+  next = pool.find(s => !displayedIds.has(s.id) && s.id !== tappedId);
+  return next ?? null;
+}
+
 export const StarterPrompts: React.FC<StarterPromptsProps> = ({
   onPromptSelect,
   personalizedStarters,
 }) => {
   const topicStarters = useMemo(() => selectRandomTopicStarters(), []);
-  const personalized = personalizedStarters ?? [];
+  // Stable pool ref: same array reference unless the input genuinely changed.
+  // personalizedStarters from React Query is referentially stable across renders
+  // when data hasn't changed, so this useMemo only re-fires on real updates.
+  const pool = useMemo(
+    () => personalizedStarters ?? EMPTY_POOL,
+    [personalizedStarters]
+  );
+  const [displayed, setDisplayed] = useState<PersonalizedStarter[]>([]);
+  const seenIdsRef = useRef<Set<string>>(new Set());
+
+  // Hydrate seenIds + initial 3 whenever the pool changes (mount, profile edit, etc.).
+  useEffect(() => {
+    if (pool.length === 0) {
+      setDisplayed([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      let seen = await getSeenStarterIds();
+      const unseen = pool.filter(s => !seen.has(s.id));
+      if (unseen.length < VISIBLE_SLOTS && pool.length >= VISIBLE_SLOTS) {
+        await clearSeenStarterIds();
+        seen = new Set();
+      }
+      if (cancelled) return;
+      seenIdsRef.current = seen;
+      setDisplayed(pickInitial(pool, seen));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [pool]);
+
+  const handlePersonalizedPress = useCallback(
+    async (starter: PersonalizedStarter, slotIndex: number) => {
+      onPromptSelect(starter.prompt);
+
+      // Persist; fire-and-forget.
+      void markStarterSeen(starter.id);
+      seenIdsRef.current.add(starter.id);
+
+      const displayedIds = new Set(displayed.map(s => s.id));
+      let next = pickReplacement(pool, displayedIds, seenIdsRef.current, starter.id);
+
+      // If pool is exhausted relative to seen, clear and try once more.
+      if (!next) {
+        const fallback = pool.find(s => !displayedIds.has(s.id) && s.id !== starter.id);
+        if (fallback) {
+          await clearSeenStarterIds();
+          seenIdsRef.current = new Set();
+          next = fallback;
+        }
+      }
+
+      if (!next) return; // pool too small to swap; leave the chip in place.
+
+      setDisplayed(current => {
+        const copy = [...current];
+        copy[slotIndex] = next!;
+        return copy;
+      });
+    },
+    [displayed, pool, onPromptSelect]
+  );
 
   return (
     <View style={styles.container}>
@@ -96,22 +199,27 @@ export const StarterPrompts: React.FC<StarterPromptsProps> = ({
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.scrollContent}
       >
-        {personalized.map(starter => (
-          <TouchableOpacity
+        {displayed.map((starter, index) => (
+          <Animated.View
             key={starter.id}
-            style={[styles.card, styles.cardPersonalized]}
-            onPress={() => onPromptSelect(starter.prompt)}
-            activeOpacity={0.8}
+            entering={FadeIn.duration(200)}
+            exiting={FadeOut.duration(150)}
           >
-            <View style={styles.cardHeader}>
-              <View style={[styles.iconBadge, { backgroundColor: starter.iconBackground }]}>
-                <Feather name={starter.iconName as keyof typeof Feather.glyphMap} size={16} color={Theme.white} />
+            <TouchableOpacity
+              style={[styles.card, styles.cardPersonalized]}
+              onPress={() => handlePersonalizedPress(starter, index)}
+              activeOpacity={0.8}
+            >
+              <View style={styles.cardHeader}>
+                <View style={[styles.iconBadge, { backgroundColor: starter.iconBackground }]}>
+                  <Feather name={starter.iconName as keyof typeof Feather.glyphMap} size={16} color={Theme.white} />
+                </View>
+                <Text style={styles.cardLabel} numberOfLines={1}>{starter.category}</Text>
+                <Feather name='chevron-right' size={16} color={Theme.textInactiveTab} />
               </View>
-              <Text style={styles.cardLabel} numberOfLines={1}>{starter.category}</Text>
-              <Feather name='chevron-right' size={16} color={Theme.textInactiveTab} />
-            </View>
-            <Text style={styles.cardDescription} numberOfLines={3}>{starter.prompt}</Text>
-          </TouchableOpacity>
+              <Text style={styles.cardDescription} numberOfLines={3}>{starter.prompt}</Text>
+            </TouchableOpacity>
+          </Animated.View>
         ))}
 
         {[...MODE_CARDS, ...topicStarters].map(card => (

--- a/unify-front-end/hooks/companion/usePersonalizedStarters.ts
+++ b/unify-front-end/hooks/companion/usePersonalizedStarters.ts
@@ -33,7 +33,29 @@ const fetchPersonalizedStarters =
     const starters = data?.companion?.starters;
     if (!Array.isArray(starters) || starters.length === 0) return null;
 
-    return { starters: starters as PersonalizedStarter[] };
+    // Validate shape — if the deployed edge function still returns the
+    // legacy string[] payload, every entry will fail this check and we'll
+    // fall back to no personalized chips rather than rendering broken cards.
+    const valid = starters.filter(
+      (s): s is PersonalizedStarter =>
+        s != null &&
+        typeof s === 'object' &&
+        typeof (s as PersonalizedStarter).id === 'string' &&
+        typeof (s as PersonalizedStarter).category === 'string' &&
+        typeof (s as PersonalizedStarter).prompt === 'string' &&
+        typeof (s as PersonalizedStarter).iconBackground === 'string' &&
+        typeof (s as PersonalizedStarter).iconName === 'string' &&
+        typeof (s as PersonalizedStarter).priority === 'number'
+    );
+    if (valid.length === 0) {
+      console.warn(
+        '[usePersonalizedStarters] edge function returned legacy/invalid shape; ' +
+          'deploy the latest personalize function to enable personalized chips.'
+      );
+      return null;
+    }
+
+    return { starters: valid };
   };
 
 export const PERSONALIZED_STARTERS_QUERY_KEY = ['personalizedStarters', 'v2'] as const;

--- a/unify-front-end/hooks/companion/usePersonalizedStarters.ts
+++ b/unify-front-end/hooks/companion/usePersonalizedStarters.ts
@@ -1,8 +1,12 @@
+// hooks/companion/usePersonalizedStarters.ts
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
+import type { PersonalizedStarter } from '@/supabase/functions/_shared/companionTemplates';
 
-interface CompanionPersonalization {
-  starters: string[];
+export type { PersonalizedStarter };
+
+export interface CompanionPersonalization {
+  starters: PersonalizedStarter[];
 }
 
 const fetchPersonalizedStarters =
@@ -26,15 +30,18 @@ const fetchPersonalizedStarters =
     if (!response.ok) return null;
 
     const data = await response.json();
-    if (!data?.companion?.starters?.length) return null;
+    const starters = data?.companion?.starters;
+    if (!Array.isArray(starters) || starters.length === 0) return null;
 
-    return { starters: data.companion.starters };
+    return { starters: starters as PersonalizedStarter[] };
   };
+
+export const PERSONALIZED_STARTERS_QUERY_KEY = ['personalizedStarters', 'v2'] as const;
 
 export const usePersonalizedStarters = () => {
   return useQuery<CompanionPersonalization | null, Error>({
-    queryKey: ['personalizedStarters'],
+    queryKey: PERSONALIZED_STARTERS_QUERY_KEY,
     queryFn: fetchPersonalizedStarters,
-    staleTime: 5 * 60 * 1000, // 5 minutes — starters don't change often
+    staleTime: 5 * 60 * 1000,
   });
 };

--- a/unify-front-end/hooks/onboarding/useSaveOnboardingProfile.ts
+++ b/unify-front-end/hooks/onboarding/useSaveOnboardingProfile.ts
@@ -4,6 +4,7 @@ import {
   OnboardingProfileInput,
   UserOnboardingProfile,
 } from '@/types/onboardingProfile';
+import { PERSONALIZED_STARTERS_QUERY_KEY } from '@/hooks/companion/usePersonalizedStarters';
 
 export const useSaveOnboardingProfile = () => {
   const queryClient = useQueryClient();
@@ -15,9 +16,8 @@ export const useSaveOnboardingProfile = () => {
   >({
     mutationFn: ({ userId, data }) => saveOnboardingProfile(userId, data),
     onSuccess: (data, variables) => {
-      // Update cache with authoritative mutation response
-      // React Query will automatically notify subscribers (AuthWrapper) to re-render
       queryClient.setQueryData(['onboardingProfile', variables.userId], data);
+      queryClient.invalidateQueries({ queryKey: PERSONALIZED_STARTERS_QUERY_KEY });
     },
   });
 };

--- a/unify-front-end/package.json
+++ b/unify-front-end/package.json
@@ -15,7 +15,10 @@
     "sync-sanity-modules": "npx tsx scripts/sync-sanity-modules.ts"
   },
   "jest": {
-    "preset": "jest-expo"
+    "preset": "jest-expo",
+    "moduleNameMapper": {
+      "^@react-native-async-storage/async-storage$": "<rootDir>/node_modules/@react-native-async-storage/async-storage/jest/async-storage-mock.js"
+    }
   },
   "expo": {
     "install": {

--- a/unify-front-end/supabase/functions/_shared/companionTemplates.ts
+++ b/unify-front-end/supabase/functions/_shared/companionTemplates.ts
@@ -71,8 +71,186 @@ export function makeStarter(
   };
 }
 
-// Templates added in Task 2.
+const PERSONA_LABELS: Record<string, string> = {
+  international_student: 'international student',
+  skilled_worker: 'skilled worker',
+  refugee: 'refugee',
+  other: 'newcomer',
+};
+
+const INTEREST_PROMPTS: Record<
+  string,
+  { category: keyof typeof CATEGORY_META; prompt: string }
+> = {
+  documents:     { category: 'Documents',         prompt: 'Which documents and IDs should I get first as a newcomer?' },
+  employment:    { category: 'Job Search',        prompt: 'How do I start my job search in Canada?' },
+  finance:       { category: 'Finance',           prompt: 'How do I open a bank account and build credit in Canada?' },
+  housing:       { category: 'Housing',           prompt: 'How do I find housing as a newcomer?' },
+  pr_immigration:{ category: 'PR & Immigration',  prompt: 'How do I apply for permanent residence?' },
+  healthcare:    { category: 'Healthcare',        prompt: 'How does provincial healthcare work for newcomers?' },
+  family_kids:   { category: 'Family',            prompt: 'What family and childcare benefits are available to newcomers?' },
+  transit:       { category: 'Transit',           prompt: 'How do I get a driver\'s licence and use public transit in my city?' },
+};
+
+const HOBBY_PROMPTS: Record<
+  string,
+  { category: keyof typeof CATEGORY_META; verb: string }
+> = {
+  career_growth:    { category: 'Job Search', verb: 'grow my career' },
+  exploring_canada: { category: 'Lifestyle',  verb: 'explore' },
+  wellness:         { category: 'Lifestyle',  verb: 'find wellness activities' },
+  technology:       { category: 'Lifestyle',  verb: 'meet other tech enthusiasts' },
+  music:            { category: 'Lifestyle',  verb: 'enjoy live music' },
+  fitness:          { category: 'Lifestyle',  verb: 'find affordable gyms and fitness classes' },
+  personal_finance: { category: 'Finance',    verb: 'manage personal finances' },
+  family_parenting: { category: 'Family',     verb: 'connect with other parents' },
+  education:        { category: 'Education',  verb: 'continue my education' },
+  food_cooking:     { category: 'Lifestyle',  verb: 'find authentic ingredients and cooking classes' },
+  movies:           { category: 'Lifestyle',  verb: 'find indie cinemas and film events' },
+};
+
+const KNOWN_CITY_CATEGORIES = new Set([
+  'Vancouver', 'Toronto', 'Montreal', 'Calgary', 'Ottawa',
+]);
+
+function cityCategory(city: string): keyof typeof CATEGORY_META {
+  return (KNOWN_CITY_CATEGORIES.has(city) ? city : 'Your City') as keyof typeof CATEGORY_META;
+}
+
+function monthsSince(isoDate: string): number {
+  const then = new Date(isoDate);
+  if (isNaN(then.getTime())) return Infinity;
+  const now = new Date();
+  return (now.getFullYear() - then.getFullYear()) * 12 +
+         (now.getMonth() - then.getMonth());
+}
+
 export const TEMPLATES: TemplateFn[] = [];
+
+TEMPLATES.push(
+  // persona + city — strongest signal
+  (p) => p.persona && p.city ? makeStarter(
+    'persona_city',
+    cityCategory(p.city),
+    `What do I need to know as a ${PERSONA_LABELS[p.persona] ?? 'newcomer'} in ${p.city}?`,
+    10,
+  ) : null,
+
+  // persona only — fallback when no city
+  (p) => p.persona && !p.city ? makeStarter(
+    'persona_only',
+    'Settlement',
+    `What resources are available for a ${PERSONA_LABELS[p.persona] ?? 'newcomer'} in Canada?`,
+    7,
+  ) : null,
+
+  // recent arrival
+  (p) => {
+    if (!p.arrival_date) return null;
+    const months = monthsSince(p.arrival_date);
+    if (months < 0 || months > 6) return null;
+    return makeStarter(
+      'arrival_recent',
+      'Settlement',
+      'I just arrived in Canada — what should I do in my first 30 days?',
+      9,
+    );
+  },
+
+  // future arrival
+  (p) => {
+    if (!p.arrival_date) return null;
+    if (monthsSince(p.arrival_date) >= 0) return null;
+    return makeStarter(
+      'arrival_future',
+      'Pre-Arrival',
+      'How should I prepare before arriving in Canada?',
+      9,
+    );
+  },
+
+  // stage-based
+  (p) => p.stage === '1' ? makeStarter(
+    'stage_planning',
+    'Documents',
+    'I\'m still planning my move — what documents do I need to start?',
+    6,
+  ) : null,
+
+  (p) => p.stage === '3' ? makeStarter(
+    'stage_recently_arrived',
+    'Settlement',
+    'What should I prioritize in my first month here?',
+    6,
+  ) : null,
+
+  // persona × employment combo
+  (p) => p.persona === 'skilled_worker' && p.learning_interests.includes('employment') ? makeStarter(
+    'persona_skilled_credentials',
+    'Job Search',
+    'How do I get my foreign credentials recognized in Canada?',
+    9,
+  ) : null,
+
+  (p) => p.persona === 'international_student' && p.learning_interests.includes('employment') ? makeStarter(
+    'persona_student_pgwp',
+    'Job Search',
+    'How do I get a post-graduation work permit (PGWP)?',
+    9,
+  ) : null,
+);
+
+// One template per learning interest
+for (const [interest, meta] of Object.entries(INTEREST_PROMPTS)) {
+  TEMPLATES.push((p) => p.learning_interests.includes(interest)
+    ? makeStarter(`interest_${interest}`, meta.category, meta.prompt, 5)
+    : null);
+}
+
+// One template per hobby (requires city)
+for (const [hobby, meta] of Object.entries(HOBBY_PROMPTS)) {
+  TEMPLATES.push((p) => {
+    if (!p.city || !p.hobbies.includes(hobby)) return null;
+    return makeStarter(
+      `hobby_${hobby}_city`,
+      meta.category,
+      `Where can I ${meta.verb} in ${p.city}?`,
+      4,
+    );
+  });
+}
+
+// Goal-mapped templates
+TEMPLATES.push(
+  (p) => p.goals.includes('learn_something') ? makeStarter(
+    'goal_learn',
+    'Education',
+    'What free learning resources are available to newcomers?',
+    5,
+  ) : null,
+
+  (p) => p.goals.includes('build_community') ? makeStarter(
+    'goal_community',
+    'Settlement',
+    'How can I meet other newcomers and build community here?',
+    5,
+  ) : null,
+
+  (p) => p.goals.includes('quick_answers') ? makeStarter(
+    'goal_quick_answers',
+    'Documents',
+    'Quick reference: what are the top documents and steps I\'ll need?',
+    5,
+  ) : null,
+
+  // pr_immigration × province
+  (p) => p.learning_interests.includes('pr_immigration') && p.province ? makeStarter(
+    'interest_pr_province',
+    'PR & Immigration',
+    `How do I apply for permanent residence from ${p.province}?`,
+    7,
+  ) : null,
+);
 
 export function buildPool(profile: OnboardingProfile): PersonalizedStarter[] {
   const out: PersonalizedStarter[] = [];

--- a/unify-front-end/supabase/functions/_shared/companionTemplates.ts
+++ b/unify-front-end/supabase/functions/_shared/companionTemplates.ts
@@ -1,0 +1,85 @@
+// supabase/functions/_shared/companionTemplates.ts
+
+// Mirrored from the edge function's OnboardingProfile so this file
+// has zero Deno-specific imports and can be loaded by jest.
+export interface OnboardingProfile {
+  persona: string | null;
+  city: string | null;
+  province: string | null;
+  arrival_date: string | null;
+  stage: string | null;
+  goals: string[];
+  learning_interests: string[];
+  hobbies: string[];
+}
+
+export type FeatherIconName =
+  | 'map-pin' | 'briefcase' | 'home' | 'heart' | 'users'
+  | 'book-open' | 'award' | 'flag' | 'file-text' | 'dollar-sign'
+  | 'globe' | 'truck' | 'compass' | 'clipboard' | 'sun';
+
+export interface PersonalizedStarter {
+  id: string;
+  category: string;
+  iconName: FeatherIconName;
+  iconBackground: string;
+  prompt: string;
+  priority: number;
+}
+
+export type TemplateFn = (profile: OnboardingProfile) => PersonalizedStarter | null;
+
+export const CATEGORY_META: Record<
+  string,
+  { iconName: FeatherIconName; iconBackground: string }
+> = {
+  Vancouver:    { iconName: 'map-pin',     iconBackground: '#5C6BC0' },
+  Toronto:      { iconName: 'map-pin',     iconBackground: '#5C6BC0' },
+  Montreal:     { iconName: 'map-pin',     iconBackground: '#5C6BC0' },
+  Calgary:      { iconName: 'map-pin',     iconBackground: '#5C6BC0' },
+  Ottawa:       { iconName: 'map-pin',     iconBackground: '#5C6BC0' },
+  'Your City':  { iconName: 'map-pin',     iconBackground: '#5C6BC0' },
+  Settlement:   { iconName: 'compass',     iconBackground: '#66BB6A' },
+  'Pre-Arrival':{ iconName: 'globe',       iconBackground: '#26A69A' },
+  Documents:    { iconName: 'file-text',   iconBackground: '#F0A04B' },
+  'Job Search': { iconName: 'briefcase',   iconBackground: '#EF5350' },
+  Healthcare:   { iconName: 'heart',       iconBackground: '#66BB6A' },
+  Housing:      { iconName: 'home',        iconBackground: '#26A69A' },
+  'PR & Immigration': { iconName: 'award', iconBackground: '#5C6BC0' },
+  Family:       { iconName: 'users',       iconBackground: '#E3A0C9' },
+  Finance:      { iconName: 'dollar-sign', iconBackground: '#F0A04B' },
+  Transit:      { iconName: 'truck',       iconBackground: '#26A69A' },
+  Lifestyle:    { iconName: 'sun',         iconBackground: '#7C5CBF' },
+  Education:    { iconName: 'book-open',   iconBackground: '#26A69A' },
+  Citizenship:  { iconName: 'flag',        iconBackground: '#E3A0C9' },
+};
+
+export function makeStarter(
+  id: string,
+  category: keyof typeof CATEGORY_META,
+  prompt: string,
+  priority: number
+): PersonalizedStarter {
+  const meta = CATEGORY_META[category];
+  return {
+    id,
+    category: category as string,
+    iconName: meta.iconName,
+    iconBackground: meta.iconBackground,
+    prompt,
+    priority,
+  };
+}
+
+// Templates added in Task 2.
+export const TEMPLATES: TemplateFn[] = [];
+
+export function buildPool(profile: OnboardingProfile): PersonalizedStarter[] {
+  const out: PersonalizedStarter[] = [];
+  for (const fn of TEMPLATES) {
+    const result = fn(profile);
+    if (result) out.push(result);
+  }
+  // Sort priority desc; stable for ties (declaration order preserved).
+  return out.sort((a, b) => b.priority - a.priority).slice(0, 30);
+}

--- a/unify-front-end/supabase/functions/personalize/index.ts
+++ b/unify-front-end/supabase/functions/personalize/index.ts
@@ -2,7 +2,7 @@
 import { createClient } from 'jsr:@supabase/supabase-js@2';
 import {
   buildPool,
-  type OnboardingProfile as CompanionProfile,
+  type OnboardingProfile,
 } from '../_shared/companionTemplates.ts';
 
 const corsHeaders = {
@@ -10,17 +10,6 @@ const corsHeaders = {
   'Access-Control-Allow-Headers':
     'authorization, x-client-info, apikey, content-type',
 };
-
-interface OnboardingProfile {
-  persona: string | null;
-  city: string | null;
-  province: string | null;
-  arrival_date: string | null;
-  stage: string | null;
-  goals: string[];
-  learning_interests: string[];
-  hobbies: string[];
-}
 
 // ─── Learn surface ────────────────────────────────────────────────────────────
 
@@ -247,7 +236,7 @@ Deno.serve(async (req: Request) => {
           interests: profile.learning_interests,
           hobbies: profile.hobbies,
         },
-        starters: buildPool(profile as CompanionProfile),
+        starters: buildPool(profile),
       };
     }
 

--- a/unify-front-end/supabase/functions/personalize/index.ts
+++ b/unify-front-end/supabase/functions/personalize/index.ts
@@ -1,5 +1,9 @@
 // @ts-ignore JSR import
 import { createClient } from 'jsr:@supabase/supabase-js@2';
+import {
+  buildPool,
+  type OnboardingProfile as CompanionProfile,
+} from '../_shared/companionTemplates.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -12,76 +16,10 @@ interface OnboardingProfile {
   city: string | null;
   province: string | null;
   arrival_date: string | null;
+  stage: string | null;
   goals: string[];
   learning_interests: string[];
-}
-
-// ─── Companion surface ────────────────────────────────────────────────────────
-
-function buildCompanionStarters(profile: OnboardingProfile): string[] {
-  const { persona, city, province, goals, learning_interests } = profile;
-
-  const starters: string[] = [];
-
-  function humanize(str: string): string {
-    return str.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-  }
-
-  if (persona && city) {
-    const personaLabel =
-      persona === 'international_student'
-        ? 'international student'
-        : persona.replace(/_/g, ' ');
-    starters.push(`What do I need to know as a ${personaLabel} in ${city}?`);
-  } else if (persona) {
-    const personaLabel = persona.replace(/_/g, ' ');
-    starters.push(
-      `What resources are available for a ${personaLabel} in Canada?`
-    );
-  }
-
-  if (goals.length > 0) {
-    const topGoal = goals[0];
-    const location = city ?? province ?? 'Canada';
-
-    if (
-      topGoal.toLowerCase().includes('work') ||
-      topGoal.toLowerCase().includes('job')
-    ) {
-      starters.push(`Help me find job opportunities in ${location}`);
-    } else if (
-      topGoal.toLowerCase().includes('english') ||
-      topGoal.toLowerCase().includes('language')
-    ) {
-      starters.push(`What language programs are available in ${location}?`);
-    } else if (topGoal.toLowerCase().includes('housing')) {
-      starters.push(`How do I find housing as a newcomer in ${location}?`);
-    } else {
-      starters.push(
-        `How do I achieve my goal to ${humanize(topGoal)} in ${location}?`
-      );
-    }
-  }
-
-  if (learning_interests.length > 0) {
-    const topInterest = learning_interests[0];
-    starters.push(
-      `What ${topInterest} opportunities are available for newcomers?`
-    );
-  }
-
-  const fallbacks = [
-    'What are the most important steps after arriving in Canada?',
-    'How does the Canadian healthcare system work?',
-    'What free settlement services are available to me?',
-  ];
-
-  for (const fallback of fallbacks) {
-    if (starters.length >= 3) break;
-    starters.push(fallback);
-  }
-
-  return starters.slice(0, 3);
+  hobbies: string[];
 }
 
 // ─── Learn surface ────────────────────────────────────────────────────────────
@@ -271,7 +209,7 @@ Deno.serve(async (req: Request) => {
     const { data: profileData, error: profileError } = await supabaseClient
       .from('user_onboarding_profiles')
       .select(
-        'persona, city, province, arrival_date, goals, learning_interests'
+        'persona, city, province, arrival_date, stage, goals, learning_interests, hobbies'
       )
       .eq('id', user.id)
       .maybeSingle();
@@ -289,8 +227,10 @@ Deno.serve(async (req: Request) => {
       city: profileData.city ?? null,
       province: profileData.province ?? null,
       arrival_date: profileData.arrival_date ?? null,
+      stage: profileData.stage ?? null,
       goals: profileData.goals ?? [],
       learning_interests: profileData.learning_interests ?? [],
+      hobbies: profileData.hobbies ?? [],
     };
 
     const responseBody: Record<string, unknown> = {};
@@ -302,10 +242,12 @@ Deno.serve(async (req: Request) => {
           city: profile.city,
           province: profile.province,
           arrival_date: profile.arrival_date,
+          stage: profile.stage,
           goals: profile.goals,
           interests: profile.learning_interests,
+          hobbies: profile.hobbies,
         },
-        starters: buildCompanionStarters(profile),
+        starters: buildPool(profile as CompanionProfile),
       };
     }
 

--- a/unify-front-end/utils/companionStarterHistory.ts
+++ b/unify-front-end/utils/companionStarterHistory.ts
@@ -1,0 +1,37 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const COMPANION_STARTER_HISTORY_KEY = '@companion_seen_starter_ids_v1';
+
+export async function getSeenStarterIds(): Promise<Set<string>> {
+  try {
+    const raw = await AsyncStorage.getItem(COMPANION_STARTER_HISTORY_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((x): x is string => typeof x === 'string'));
+  } catch {
+    return new Set();
+  }
+}
+
+export async function markStarterSeen(id: string): Promise<void> {
+  try {
+    const current = await getSeenStarterIds();
+    if (current.has(id)) return;
+    current.add(id);
+    await AsyncStorage.setItem(
+      COMPANION_STARTER_HISTORY_KEY,
+      JSON.stringify(Array.from(current))
+    );
+  } catch {
+    // Best effort — failing means the chip might re-appear next session.
+  }
+}
+
+export async function clearSeenStarterIds(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(COMPANION_STARTER_HISTORY_KEY);
+  } catch {
+    // No-op.
+  }
+}

--- a/unify-front-end/utils/companionStarterHistory.ts
+++ b/unify-front-end/utils/companionStarterHistory.ts
@@ -2,7 +2,27 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const COMPANION_STARTER_HISTORY_KEY = '@companion_seen_starter_ids_v1';
 
-export async function getSeenStarterIds(): Promise<Set<string>> {
+// Serialize all read-modify-write operations on the seen-starter set.
+// Concurrent fire-and-forget markStarterSeen() calls (e.g. when the user taps
+// two chips in rapid succession) would otherwise read the same pre-write state
+// and the last writer wins, dropping the earlier id. The queue makes each
+// mutation see the committed result of the previous one.
+let writeQueue: Promise<unknown> = Promise.resolve();
+
+function enqueue<T>(fn: () => Promise<T>): Promise<T> {
+  // Always run after the previous tail, regardless of whether it failed.
+  const result = writeQueue.then(fn, fn);
+  // Keep the chain tail resolvable so a failure doesn't poison subsequent work.
+  writeQueue = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+}
+
+// Bypasses the queue; safe to use only from within an enqueued operation,
+// or from external readers that have already awaited writeQueue.
+async function readRaw(): Promise<Set<string>> {
   try {
     const raw = await AsyncStorage.getItem(COMPANION_STARTER_HISTORY_KEY);
     if (!raw) return new Set();
@@ -14,24 +34,34 @@ export async function getSeenStarterIds(): Promise<Set<string>> {
   }
 }
 
-export async function markStarterSeen(id: string): Promise<void> {
-  try {
-    const current = await getSeenStarterIds();
-    if (current.has(id)) return;
-    current.add(id);
-    await AsyncStorage.setItem(
-      COMPANION_STARTER_HISTORY_KEY,
-      JSON.stringify(Array.from(current))
-    );
-  } catch {
-    // Best effort — failing means the chip might re-appear next session.
-  }
+export async function getSeenStarterIds(): Promise<Set<string>> {
+  // Wait for any pending mutation to settle so callers see the post-write state.
+  await writeQueue.catch(() => undefined);
+  return readRaw();
 }
 
-export async function clearSeenStarterIds(): Promise<void> {
-  try {
-    await AsyncStorage.removeItem(COMPANION_STARTER_HISTORY_KEY);
-  } catch {
-    // No-op.
-  }
+export function markStarterSeen(id: string): Promise<void> {
+  return enqueue(async () => {
+    try {
+      const current = await readRaw();
+      if (current.has(id)) return;
+      current.add(id);
+      await AsyncStorage.setItem(
+        COMPANION_STARTER_HISTORY_KEY,
+        JSON.stringify(Array.from(current))
+      );
+    } catch {
+      // Best effort — failing means the chip might re-appear next session.
+    }
+  });
+}
+
+export function clearSeenStarterIds(): Promise<void> {
+  return enqueue(async () => {
+    try {
+      await AsyncStorage.removeItem(COMPANION_STARTER_HISTORY_KEY);
+    } catch {
+      // No-op.
+    }
+  });
 }


### PR DESCRIPTION
## Summary

The AI Companion's "For You" starter chips now:
- Use the **full onboarding profile** (persona, city, province, arrival date, stage, all goals, all interests, hobbies) instead of just `persona + city + goal[0] + interest[0]`.
- Show **topic-derived labels** per chip (e.g. "Vancouver", "Job Search", "Healthcare") instead of all reading "For You".
- **Refresh on tap** — when a chip is tapped, that slot fades out and a fresh unseen prompt fades in. Tapped chips are remembered across app restarts via `AsyncStorage`.

Mode chips (Fact Check, Form Help) and topic chips (Express Entry, CRS Score, etc.) are unchanged.

## Architecture

- **Edge function**: `personalize` now consumes a shared template pool from `supabase/functions/_shared/companionTemplates.ts`. Each template is a pure function that emits a `PersonalizedStarter` (or null) given a profile. The pool is sorted by `priority` desc and capped at 30 entries. Already deployed (v28).
- **Client**: `usePersonalizedStarters` hook bumps cache key to `v2` and validates payload shape (defensive against legacy `string[]` responses). `useSaveOnboardingProfile` invalidates the personalized-starters query on profile edits so chips refresh immediately.
- **`StarterPrompts.tsx`**: hydrates `seenIds` from `AsyncStorage` on mount, picks the top 3 unseen by priority, and on tap replaces the tapped slot with the next unseen entry. Each chip is wrapped in a keyed `<View>` so a key change unmounts/remounts the inner `<Animated.View>` — `FadeOut` fires on the old chip, `FadeIn` on the new.

## Tests

17 new tests, 57 total passing:
- `companionTemplates.test.ts` (11): pool emits correct templates per signal, sorts by priority, caps at 30, stable IDs.
- `companionStarterHistory.test.ts` (6): AsyncStorage helpers persist, dedupe, clear, and survive malformed JSON.

## Test plan

- [ ] Tap a personalized chip → it sends the message AND a different chip fades in to replace it
- [ ] Tap repeatedly until the pool exhausts → rotation continues, chips re-appear after the seen-set clears
- [ ] Quit and relaunch the app → tapped chips do NOT immediately reappear
- [ ] Onboard a new test user with only `persona` set → chips render without crashing
- [ ] Onboard a fully-completed test user → ≥ 5 distinct categories appear across chips
- [ ] Edit `city` from a profile screen → personalized chips refresh within seconds
- [ ] Mode chips ("Fact Check", "Form Help") and topic chips do NOT swap on tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personalized companion starter carousel displays tailored conversation suggestions that cycle on tap
  * History tracking persists viewed suggestions across sessions to reduce repetition

* **Refactor**
  * Template generation refactored to shared module for improved consistency

* **Tests**
  * Added comprehensive test coverage for starter history persistence and template generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->