### PR TITLE
feat(comments): reply chains with @mention prefix and Replying-to pill

### DIFF
--- a/unify-front-end/app/(tabs)/Gather/PostCommentItem.tsx
+++ b/unify-front-end/app/(tabs)/Gather/PostCommentItem.tsx
@@ -413,9 +413,12 @@ const styles = StyleSheet.create({
   connectorLine: {
     position: 'absolute',
     left: 0,
-    top: -8,
-    bottom: 12,
+    // Anchor near the parent's footer area and hook into the first reply's
+    // avatar with a short L-shape. Don't span the full reply group — that
+    // pushes the curve to the bottom (wrong place) and looks orphaned.
+    top: -20,
     width: 16,
+    height: 40,
     borderLeftWidth: 1,
     borderLeftColor: Theme.textInactiveTab,
     borderBottomWidth: 1,

--- a/unify-front-end/app/(tabs)/Gather/PostCommentItem.tsx
+++ b/unify-front-end/app/(tabs)/Gather/PostCommentItem.tsx
@@ -179,18 +179,19 @@ const PostCommentItem = memo(
 
             {/* Description */}
             <Text style={styles.description}>
-              {isReply && parentAuthorUsername && (
-                <Text
-                  style={styles.mention}
-                  onPress={() => {
-                    if (parentAuthorUserId) {
-                      router.push(`/profile?userId=${parentAuthorUserId}`);
+              {isReply &&
+                parentAuthorUsername &&
+                parentAuthorUserId &&
+                parentAuthorUserId !== currentUser?.id && (
+                  <Text
+                    style={styles.mention}
+                    onPress={() =>
+                      router.push(`/profile?userId=${parentAuthorUserId}`)
                     }
-                  }}
-                >
-                  @{parentAuthorUsername}{' '}
-                </Text>
-              )}
+                  >
+                    @{parentAuthorUsername}{' '}
+                  </Text>
+                )}
               {comment.content}
             </Text>
 
@@ -217,7 +218,7 @@ const PostCommentItem = memo(
                   <Text style={styles.footerText}>{likeCount}</Text>
                 )}
               </View>
-              {onReply && (
+              {!isReply && onReply && (
                 <TouchableOpacity
                   onPress={() => onReply(comment)}
                   style={styles.replyButton}

--- a/unify-front-end/app/(tabs)/Gather/PostCommentItem.tsx
+++ b/unify-front-end/app/(tabs)/Gather/PostCommentItem.tsx
@@ -27,11 +27,25 @@ interface PostCommentItemProps {
   metadata?: {
     isLiked: boolean;
     likeCount: number;
-    // TODO: when replies to comments are implemented
-    // replyCount: number
   };
   metadataLoading?: boolean;
   postAuthorId?: string; // ID of the user who created the parent post
+
+  // Reply-thread props (only set when this comment renders as a top-level
+  // comment with a reply group). When `isReply` is true, these stay undefined
+  // because we never nest a second level — that's what enforces two-level
+  // flat threading at the type level.
+  replies?: PostCommentData[];
+  repliesMetadata?: Record<number, { isLiked: boolean; likeCount: number }>;
+  commentById?: Map<number, PostCommentData>;
+
+  // Direct-target metadata for the @mention prefix on a reply. Set only when
+  // `isReply` is true.
+  parentAuthorUsername?: string;
+  parentAuthorUserId?: string;
+
+  onReply?: (comment: PostCommentData) => void;
+  isReply?: boolean;
 }
 
 const PostCommentItem = memo(
@@ -40,9 +54,17 @@ const PostCommentItem = memo(
     metadata,
     metadataLoading,
     postAuthorId,
+    replies,
+    repliesMetadata,
+    commentById,
+    parentAuthorUsername,
+    parentAuthorUserId,
+    onReply,
+    isReply = false,
   }: PostCommentItemProps) => {
     const { currentUser } = useCurrentUser();
     const [deleteModalVisible, setDeleteModalVisible] = useState(false);
+    const [repliesExpanded, setRepliesExpanded] = useState(false);
 
     // Hook for liking and unliking comments
     const likeCommentMutation = useMutateLikeComment();
@@ -103,18 +125,34 @@ const PostCommentItem = memo(
     const likeCount = metadata?.likeCount ?? 0;
     const isLiked = metadata?.isLiked;
 
+    const replyCount = replies?.length ?? 0;
+    const replyToggleLabel = repliesExpanded
+      ? 'Hide replies'
+      : `View ${replyCount} ${replyCount === 1 ? 'reply' : 'replies'}`;
+
+    const avatarSize = isReply ? 32 : 40;
+
     return (
       <View>
-        <View style={styles.postContainer}>
+        <View
+          style={[styles.postContainer, isReply && styles.postContainerReply]}
+        >
           {/* Headshot */}
           <TouchableOpacity
-            style={styles.headshot}
+            style={[
+              styles.headshot,
+              {
+                width: avatarSize,
+                height: avatarSize,
+                borderRadius: avatarSize / 2,
+              },
+            ]}
             onPress={navigateToUserProfile}
           >
             <Avatar
               profilePictureUrl={comment.profilePictureUrl}
               username={comment.username}
-              size={40}
+              size={avatarSize}
             />
           </TouchableOpacity>
 
@@ -140,37 +178,95 @@ const PostCommentItem = memo(
             </View>
 
             {/* Description */}
-            <Text style={styles.description}>{comment.content}</Text>
+            <Text style={styles.description}>
+              {isReply && parentAuthorUsername && (
+                <Text
+                  style={styles.mention}
+                  onPress={() => {
+                    if (parentAuthorUserId) {
+                      router.push(`/profile?userId=${parentAuthorUserId}`);
+                    }
+                  }}
+                >
+                  @{parentAuthorUsername}{' '}
+                </Text>
+              )}
+              {comment.content}
+            </Text>
 
             {/* Footer */}
             <View style={styles.footer}>
-              <>
-                <View style={styles.footerItem}>
-                  <TouchableOpacity
-                    onPress={() => {
-                      if (isLiked !== undefined && !metadataLoading) {
-                        toggleLike(comment.id, isLiked);
-                      }
-                    }}
-                    disabled={metadataLoading}
-                  >
-                    {isLiked ? (
-                      <Like_Fill width={20} height={20} />
-                    ) : (
-                      <Like width={20} height={20} />
-                    )}
-                  </TouchableOpacity>
-                  {metadataLoading ? (
-                    <SkeletonLoader width={24} height={20} />
+              <View style={styles.footerItem}>
+                <TouchableOpacity
+                  onPress={() => {
+                    if (isLiked !== undefined && !metadataLoading) {
+                      toggleLike(comment.id, isLiked);
+                    }
+                  }}
+                  disabled={metadataLoading}
+                >
+                  {isLiked ? (
+                    <Like_Fill width={20} height={20} />
                   ) : (
-                    <Text style={styles.footerText}>{likeCount}</Text>
+                    <Like width={20} height={20} />
                   )}
-                </View>
-              </>
+                </TouchableOpacity>
+                {metadataLoading ? (
+                  <SkeletonLoader width={24} height={20} />
+                ) : (
+                  <Text style={styles.footerText}>{likeCount}</Text>
+                )}
+              </View>
+              {onReply && (
+                <TouchableOpacity
+                  onPress={() => onReply(comment)}
+                  style={styles.replyButton}
+                  hitSlop={6}
+                >
+                  <Text style={styles.replyButtonText}>Reply</Text>
+                </TouchableOpacity>
+              )}
             </View>
+
+            {!isReply && replyCount > 0 && (
+              <TouchableOpacity
+                onPress={() => setRepliesExpanded(prev => !prev)}
+                style={styles.repliesToggle}
+                hitSlop={6}
+              >
+                <Text style={styles.repliesToggleText}>{replyToggleLabel}</Text>
+              </TouchableOpacity>
+            )}
           </View>
         </View>
-        <View style={styles.divider} />
+
+        {!isReply && replyCount > 0 && repliesExpanded && (
+          <View style={styles.repliesContainer}>
+            <View style={styles.connectorLine} />
+            {replies!.map(reply => {
+              const directParent =
+                reply.parent_comment_id != null
+                  ? commentById?.get(reply.parent_comment_id)
+                  : undefined;
+              return (
+                <PostCommentItem
+                  key={reply.id}
+                  comment={reply}
+                  metadata={repliesMetadata?.[reply.id]}
+                  metadataLoading={metadataLoading}
+                  postAuthorId={postAuthorId}
+                  commentById={commentById}
+                  parentAuthorUsername={directParent?.username}
+                  parentAuthorUserId={directParent?.user_id}
+                  onReply={onReply}
+                  isReply
+                />
+              );
+            })}
+          </View>
+        )}
+
+        {!isReply && <View style={styles.divider} />}
 
         {/* Delete Modal */}
         <Modal
@@ -226,6 +322,10 @@ const styles = StyleSheet.create({
     paddingTop: 16,
     paddingBottom: 12,
     gap: 12,
+  },
+  postContainerReply: {
+    paddingTop: 12,
+    paddingBottom: 8,
   },
   postContent: {
     flex: 1,
@@ -284,6 +384,47 @@ const styles = StyleSheet.create({
   footerText: {
     marginLeft: 4,
     fontSize: 14,
+  },
+  replyButton: {
+    marginLeft: 20,
+    paddingVertical: 4,
+    paddingHorizontal: 4,
+  },
+  replyButtonText: {
+    fontSize: 14,
+    color: Theme.textPostTime,
+    fontWeight: '500',
+  },
+  repliesToggle: {
+    marginTop: 10,
+    paddingVertical: 4,
+    alignSelf: 'flex-start',
+  },
+  repliesToggleText: {
+    fontSize: 14,
+    color: Theme.textPostTime,
+    fontWeight: '500',
+  },
+  repliesContainer: {
+    marginLeft: 32,
+    paddingLeft: 20,
+    position: 'relative',
+  },
+  connectorLine: {
+    position: 'absolute',
+    left: 0,
+    top: -8,
+    bottom: 12,
+    width: 16,
+    borderLeftWidth: 1,
+    borderLeftColor: Theme.textInactiveTab,
+    borderBottomWidth: 1,
+    borderBottomColor: Theme.textInactiveTab,
+    borderBottomLeftRadius: 12,
+  },
+  mention: {
+    color: Theme.mentionBlue,
+    fontWeight: '500',
   },
   divider: {
     width: '100%',

--- a/unify-front-end/components/home/PostDetails.tsx
+++ b/unify-front-end/components/home/PostDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -30,6 +30,7 @@ import LoadingScreen from '@/components/LoadingScreen';
 import ImageViewerModal from '@/components/home/ImageViewerModal';
 import { useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
+import { Feather } from '@expo/vector-icons';
 
 // Loading state component
 const CommentsLoadingState = () => (
@@ -52,21 +53,19 @@ const PostNotFound = () => (
 );
 
 // Comment input component
-const CommentInput = ({
-  placeholder,
-  value,
-  onChangeText,
-  onSend,
-  disabled,
-}: {
-  placeholder: string;
-  value: string;
-  onChangeText: (text: string) => void;
-  onSend: () => void;
-  disabled: boolean;
-}) => (
+const CommentInput = React.forwardRef<
+  TextInput,
+  {
+    placeholder: string;
+    value: string;
+    onChangeText: (text: string) => void;
+    onSend: () => void;
+    disabled: boolean;
+  }
+>(({ placeholder, value, onChangeText, onSend, disabled }, ref) => (
   <View style={styles.commentInputContainer}>
     <TextInput
+      ref={ref}
       style={styles.commentInput}
       placeholder={placeholder}
       value={value}
@@ -89,7 +88,8 @@ const CommentInput = ({
       </View>
     </TouchableOpacity>
   </View>
-);
+));
+CommentInput.displayName = 'CommentInput';
 
 const PostDetails = () => {
   const { post: postParam, postId: postIdParam } = useLocalSearchParams<{
@@ -134,6 +134,49 @@ const PostDetails = () => {
   const { data: commentsData, isLoading: commentsLoading } = useGetPostComments(
     post?.id
   );
+
+  // TODO(scale): When a single comment regularly has 50+ replies, switch to
+  // lazy-fetched replies (Approach 3 in the design doc). Requires a new
+  // useGetCommentReplies(parentId) hook, server-side reply_count on comment
+  // metadata, and per-thread loading state.
+  // See docs/superpowers/specs/2026-04-28-reply-chains-design.md
+  const { topLevelComments, repliesByParent, commentById } = useMemo(() => {
+    const top: PostCommentData[] = [];
+    const replies = new Map<number, PostCommentData[]>();
+    const byId = new Map<number, PostCommentData>();
+    for (const c of commentsData ?? []) {
+      byId.set(c.id, c);
+      if (c.parent_comment_id == null) {
+        top.push(c);
+      } else {
+        const arr = replies.get(c.parent_comment_id) ?? [];
+        arr.push(c);
+        replies.set(c.parent_comment_id, arr);
+      }
+    }
+    for (const arr of replies.values()) {
+      arr.sort((a, b) => a.created_at.localeCompare(b.created_at));
+    }
+    return {
+      topLevelComments: top,
+      repliesByParent: replies,
+      commentById: byId,
+    };
+  }, [commentsData]);
+
+  const [replyingTo, setReplyingTo] = useState<{
+    comment: PostCommentData;
+    threadRootId: number;
+  } | null>(null);
+
+  const inputRef = useRef<TextInput>(null);
+
+  const onReply = useCallback((comment: PostCommentData) => {
+    const threadRootId = comment.parent_comment_id ?? comment.id;
+    setReplyingTo({ comment, threadRootId });
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, []);
+
   const commentIds =
     commentsData?.map((comment: PostCommentData) => comment.id) ?? [];
   const { data: commentMetadata, isLoading: commentMetadataLoading } =
@@ -156,9 +199,20 @@ const PostDetails = () => {
         metadata={commentMetadata?.[item.id]}
         metadataLoading={commentMetadataLoading}
         postAuthorId={post?.user?.id?.toString() ?? ''}
+        replies={repliesByParent.get(item.id)}
+        repliesMetadata={commentMetadata}
+        commentById={commentById}
+        onReply={onReply}
       />
     ),
-    [commentMetadata, commentMetadataLoading, post?.user?.id]
+    [
+      commentMetadata,
+      commentMetadataLoading,
+      post?.user?.id,
+      repliesByParent,
+      commentById,
+      onReply,
+    ]
   );
 
   // Early returns only after all hooks have been called
@@ -185,10 +239,12 @@ const PostDetails = () => {
       {
         postId: post.id,
         content: commentTextBox,
+        parentCommentId: replyingTo?.threadRootId ?? null,
       },
       {
         onSuccess: () => {
           setCommentTextBox('');
+          setReplyingTo(null);
           Keyboard.dismiss();
         },
       }
@@ -200,7 +256,7 @@ const PostDetails = () => {
       <BackHeader onBack={onBack} />
 
       <FlatList
-        data={commentsData}
+        data={topLevelComments}
         keyExtractor={item => item.id.toString()}
         renderItem={renderPost}
         contentContainerStyle={{ paddingBottom: 25 }}
@@ -253,8 +309,23 @@ const PostDetails = () => {
       />
 
       <Animated.View style={[styles.commentInputSafeArea, inputAnimatedStyle]}>
+        {replyingTo && (
+          <View style={styles.replyingToPill}>
+            <Text style={styles.replyingToText}>
+              Replying to {replyingTo.comment.username}
+            </Text>
+            <TouchableOpacity onPress={() => setReplyingTo(null)} hitSlop={8}>
+              <Feather name='x' size={18} color={Theme.textPostTime} />
+            </TouchableOpacity>
+          </View>
+        )}
         <CommentInput
-          placeholder={`Reply to ${post.user.name}`}
+          ref={inputRef}
+          placeholder={
+            replyingTo
+              ? `Reply to ${replyingTo.comment.username}`
+              : `Reply to ${post.user.name}`
+          }
           value={commentTextBox}
           onChangeText={setCommentTextBox}
           onSend={handleCreateComment}
@@ -306,6 +377,21 @@ const styles = StyleSheet.create({
   },
   commentInputSafeArea: {
     backgroundColor: '#fff',
+  },
+  replyingToPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    backgroundColor: Theme.surfaceTextInput,
+    borderTopWidth: 1,
+    borderTopColor: '#E5E5E5',
+  },
+  replyingToText: {
+    fontSize: 14,
+    color: Theme.textPostTime,
+    fontWeight: '500',
   },
   commentInput: {
     flex: 1,

--- a/unify-front-end/constants/Theme.ts
+++ b/unify-front-end/constants/Theme.ts
@@ -21,6 +21,8 @@ export const Theme = {
   surfaceBlue: '#5182C7',
   surfaceEventCard: '#F9F9F9',
 
+  mentionBlue: '#007AFF',
+
   backgroundChatbot: '#F3F2F2',
 
   imagePlaceholder: '#D3D3D3',

--- a/unify-front-end/services/posts/getPostComments.ts
+++ b/unify-front-end/services/posts/getPostComments.ts
@@ -21,6 +21,7 @@ export const getPostComments = async (
         `
       )
       .eq('post_id', Number(postId))
+      .order('parent_comment_id', { ascending: true, nullsFirst: true })
       .order('created_at', { ascending: false });
 
     if (error) throw error;

--- a/unify-front-end/supabase/migrations/20260428165642_cascade_delete_comment_replies.sql
+++ b/unify-front-end/supabase/migrations/20260428165642_cascade_delete_comment_replies.sql
@@ -1,0 +1,11 @@
+-- Cascade-delete reply comments when their parent comment is deleted.
+-- Replaces the existing FK (ON DELETE SET NULL) with ON DELETE CASCADE
+-- so orphaned replies don't surface as top-level comments after a parent
+-- is removed.
+
+ALTER TABLE post_comments
+  DROP CONSTRAINT post_comments_parent_comment_id_fkey,
+  ADD CONSTRAINT post_comments_parent_comment_id_fkey
+    FOREIGN KEY (parent_comment_id)
+    REFERENCES post_comments(id)
+    ON DELETE CASCADE;


### PR DESCRIPTION
## Summary

Adds Instagram-style two-level reply threading to post comments in the home-feed `PostDetails` screen.

- **Two-level flat threading**: replies to replies still nest under the same top-level parent (no infinite indent on mobile).
- **"View N replies" toggle**: replies collapsed by default; tap to expand. Singular/plural-aware label.
- **"Replying to @username ✕" pill**: appears above the existing `CommentInput` when you tap Reply on a top-level comment. Dismissable, preserves draft text on swap or cancel.
- **Curved connector line**: hooks from above into the first reply's avatar (matches design reference).
- **`@mention` prefix on replies**: rendered in iOS blue (`#007AFF`), tappable to open that user's profile. Suppressed when the target would be the current user (no @-yourself).
- **Reply button only on top-level comments**: forces all replies to target the thread root, keeping the @mention always correct (architectural consequence of two-level flat threading).
- **Cascade-delete migration**: parent comment delete now removes its replies (was `SET NULL`, now `CASCADE`).

Spec: `docs/superpowers/specs/2026-04-28-reply-chains-design.md` (local).
Plan: `docs/superpowers/plans/2026-04-28-comment-reply-chains.md` (local).

Backend was already wired (`post_comments.parent_comment_id`, `createComment(parentCommentId)`, `createCommentReplyNotification`) — this is frontend + the FK migration only.

## Test plan

- [ ] Tap **Reply** on a top-level comment → "Replying to {username}" pill appears, input auto-focuses, placeholder reads "Reply to {username}".
- [ ] Send a reply → it appears under that thread (oldest-first within the thread).
- [ ] **"View N replies"** toggle collapses/expands replies; label switches to **"Hide replies"** when expanded. Singular form for 1 reply.
- [ ] Curved connector line hooks into the first reply's avatar from above.
- [ ] `@username` mention renders in iOS blue. Tapping navigates to that user's profile.
- [ ] Reply on a reply: button is gone (only top-level comments have Reply).
- [ ] Reply to your own top-level comment: `@yourself` mention is suppressed; just the body shows.
- [ ] Tap Reply on A → type "draft" → tap Reply on B (without sending) → pill swaps to B, "draft" preserved.
- [ ] Tap ✕ on the pill → dismisses, draft preserved, sending creates a top-level comment.
- [ ] Delete a parent comment that has replies → replies disappear (FK cascade applied to prod DB).
- [ ] Home-feed `PostItem` "X comments" badge increments for replies (matches Instagram/Twitter convention).
- [ ] Push notification: account A replies to account B's comment → B receives a `comment_reply` push.
- [ ] Keyboard animation (`useReanimatedKeyboardAnimation`) still rises smoothly with the pill present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comment reply support with two-level threading display
  * Replies now include mentions of the parent author
  * Added "Replying to" indicator when composing a reply to a comment
  * Reply threads can be collapsed and expanded for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->