### PR TITLE
feat(analytics): identify users + close coverage gaps + new dashboards

### DIFF
--- a/unify-front-end/app/(tabs)/companion/index.tsx
+++ b/unify-front-end/app/(tabs)/companion/index.tsx
@@ -306,9 +306,17 @@ export default function CompanionScreen() {
   );
 
   // Handle starter prompt selection
-  const handleStarterPromptSelect = (prompt: string, mode?: string) => {
+  const handleStarterPromptSelect = (
+    prompt: string,
+    mode?: string,
+    isPersonalized?: boolean
+  ) => {
     // Track the starter prompt usage (empty prompt defaults to 'Ask Anything')
-    trackCompanionStarterPromptUsed(prompt || 'Ask Anything', mode);
+    trackCompanionStarterPromptUsed(
+      prompt || 'Ask Anything',
+      mode,
+      isPersonalized
+    );
 
     // "Ask Anything" - show bot greeting message
     if (prompt === '' && !mode) {

--- a/unify-front-end/app/_layout.tsx
+++ b/unify-front-end/app/_layout.tsx
@@ -145,8 +145,21 @@ function useAnalyticsIdentitySync() {
   const { identify, reset } = useAnalytics();
   const lastIdRef = useRef<string | null>(null);
   const lastTraitsRef = useRef<string>('');
+  const hasInitializedRef = useRef(false);
 
   useEffect(() => {
+    // Cold-start: PostHog persists distinct_id to AsyncStorage, so on app
+    // launch the SDK may still hold the prior session's identity. If the
+    // user isn't authenticated when this effect first runs, clear that
+    // stale identity so pre-auth events (auth screens, app_opened) don't
+    // get attributed to whoever was last logged in on this device.
+    if (!hasInitializedRef.current) {
+      hasInitializedRef.current = true;
+      if (!currentUser?.id) {
+        reset();
+      }
+    }
+
     if (currentUser?.id) {
       const traits = {
         email: currentUser.email,

--- a/unify-front-end/app/_layout.tsx
+++ b/unify-front-end/app/_layout.tsx
@@ -6,14 +6,15 @@ import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { ScrollContextProvider } from '@/context/ScrollContext';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import * as SplashScreen from 'expo-splash-screen';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import 'react-native-reanimated';
 import AuthWrapper from '@/components/AuthComponents/AuthWrapper';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { PostHogProvider } from 'posthog-react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import PreLoginOnboarding from '@/components/onboarding/PreLoginOnboarding';
-import { UserProvider } from '@/context/UserContext';
+import { UserProvider, useCurrentUser } from '@/context/UserContext';
+import { useAnalytics } from '@/utils/analytics';
 import { usePushNotifications } from '@/hooks/usePushNotifications';
 import { HapticsProvider } from '@/context/HapticsContext';
 import { ToastProvider } from '@/context/ToastContext';
@@ -135,11 +136,55 @@ export default function RootLayout() {
 }
 
 /**
+ * Syncs PostHog identity with the current authenticated user.
+ * - identify on sign-in / user-info load
+ * - reset when the user signs out (id transitions to null)
+ */
+function useAnalyticsIdentitySync() {
+  const { currentUser } = useCurrentUser();
+  const { identify, reset } = useAnalytics();
+  const lastIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (currentUser?.id && currentUser.id !== lastIdRef.current) {
+      identify(currentUser.id, {
+        email: currentUser.email,
+        username: currentUser.username,
+        persona: currentUser.persona ?? null,
+        is_premium: currentUser.isPremium,
+        city: currentUser.city,
+        province: currentUser.province,
+        arrival_date: currentUser.arrivalDate,
+        stage: currentUser.stage,
+      });
+      lastIdRef.current = currentUser.id;
+    } else if (!currentUser?.id && lastIdRef.current) {
+      reset();
+      lastIdRef.current = null;
+    }
+  }, [
+    currentUser?.id,
+    currentUser?.email,
+    currentUser?.username,
+    currentUser?.persona,
+    currentUser?.isPremium,
+    currentUser?.city,
+    currentUser?.province,
+    currentUser?.arrivalDate,
+    currentUser?.stage,
+    identify,
+    reset,
+  ]);
+}
+
+/**
  * Inner component that has access to UserContext for push notifications
  */
 function AppContent() {
   // Initialize push notifications (requires UserContext)
   usePushNotifications();
+  // Identify the user with PostHog whenever auth state resolves
+  useAnalyticsIdentitySync();
 
   return (
     <Stack>

--- a/unify-front-end/app/_layout.tsx
+++ b/unify-front-end/app/_layout.tsx
@@ -144,10 +144,11 @@ function useAnalyticsIdentitySync() {
   const { currentUser } = useCurrentUser();
   const { identify, reset } = useAnalytics();
   const lastIdRef = useRef<string | null>(null);
+  const lastTraitsRef = useRef<string>('');
 
   useEffect(() => {
-    if (currentUser?.id && currentUser.id !== lastIdRef.current) {
-      identify(currentUser.id, {
+    if (currentUser?.id) {
+      const traits = {
         email: currentUser.email,
         username: currentUser.username,
         persona: currentUser.persona ?? null,
@@ -156,11 +157,21 @@ function useAnalyticsIdentitySync() {
         province: currentUser.province,
         arrival_date: currentUser.arrivalDate,
         stage: currentUser.stage,
-      });
-      lastIdRef.current = currentUser.id;
+      };
+      const traitsKey = JSON.stringify(traits);
+      const idChanged = currentUser.id !== lastIdRef.current;
+      const traitsChanged = traitsKey !== lastTraitsRef.current;
+      // Re-send identify when the user changes OR any tracked trait changes
+      // (persona, city, premium, etc.) so PostHog person properties stay fresh.
+      if (idChanged || traitsChanged) {
+        identify(currentUser.id, traits);
+        lastIdRef.current = currentUser.id;
+        lastTraitsRef.current = traitsKey;
+      }
     } else if (!currentUser?.id && lastIdRef.current) {
       reset();
       lastIdRef.current = null;
+      lastTraitsRef.current = '';
     }
   }, [
     currentUser?.id,

--- a/unify-front-end/app/account-settings.tsx
+++ b/unify-front-end/app/account-settings.tsx
@@ -35,7 +35,8 @@ export default function AccountSettingsPage() {
   const [deleteAccountModalVisible, setDeleteAccountModalVisible] =
     useState(false);
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
-  const { trackScreen } = useAnalytics();
+  const { trackScreen, trackUserSignedOut, trackAccountDeleted } =
+    useAnalytics();
   const { hapticsEnabled, setHapticsEnabled } = useHapticsPreference();
   const { data: onboardingProfile } = useOnboardingProfile(currentUser?.id);
   const queryClient = useQueryClient();
@@ -57,13 +58,15 @@ export default function AccountSettingsPage() {
 
   const onLogout = async () => {
     try {
+      trackUserSignedOut('manual');
       try {
         await unregisterPushToken();
       } catch (e) {
         console.error('Failed to unregister push token on logout:', e);
       }
       await supabase.auth.signOut();
-      // Let AuthWrapper handle the navigation
+      // useAnalyticsIdentitySync calls posthog.reset() on session change.
+      // AuthWrapper handles navigation.
     } catch (err) {
       console.error('Logout failed', err);
     }
@@ -100,11 +103,20 @@ export default function AccountSettingsPage() {
       }
       const { error } = await supabase.rpc('delete_user');
       if (error) throw error;
+      trackAccountDeleted();
       setDeleteAccountModalVisible(false);
       Alert.alert(
         'Account deleted',
         'Your Unify account has been permanently deleted.',
-        [{ text: 'OK', onPress: () => supabase.auth.signOut() }]
+        [
+          {
+            text: 'OK',
+            onPress: () => {
+              trackUserSignedOut('account_deleted');
+              supabase.auth.signOut();
+            },
+          },
+        ]
       );
     } catch (err) {
       console.error('Delete account failed', err);

--- a/unify-front-end/app/account-settings.tsx
+++ b/unify-front-end/app/account-settings.tsx
@@ -58,15 +58,16 @@ export default function AccountSettingsPage() {
 
   const onLogout = async () => {
     try {
-      trackUserSignedOut('manual');
       try {
         await unregisterPushToken();
       } catch (e) {
         console.error('Failed to unregister push token on logout:', e);
       }
       await supabase.auth.signOut();
-      // useAnalyticsIdentitySync calls posthog.reset() on session change.
-      // AuthWrapper handles navigation.
+      // Track only after signOut resolves successfully — otherwise a failed
+      // signOut would record a phantom user_signed_out.
+      // useAnalyticsIdentitySync handles posthog.reset() on session change.
+      trackUserSignedOut('manual');
     } catch (err) {
       console.error('Logout failed', err);
     }
@@ -111,9 +112,16 @@ export default function AccountSettingsPage() {
         [
           {
             text: 'OK',
-            onPress: () => {
-              trackUserSignedOut('account_deleted');
-              supabase.auth.signOut();
+            onPress: async () => {
+              try {
+                await supabase.auth.signOut();
+                trackUserSignedOut('account_deleted');
+              } catch (e) {
+                console.error(
+                  'Sign-out after account delete failed:',
+                  e
+                );
+              }
             },
           },
         ]

--- a/unify-front-end/app/followers-following.tsx
+++ b/unify-front-end/app/followers-following.tsx
@@ -16,6 +16,7 @@ import BackHeader from '@/components/BackHeader';
 import { Theme } from '@/constants/Theme';
 import { FollowButton } from '@/components/profile/FollowButton';
 import { useCurrentUser } from '@/context/UserContext';
+import type { FollowSource } from '@/utils/analytics';
 
 export const navigationOptions = {
   headerShown: false,
@@ -30,9 +31,10 @@ interface UserListItemProps {
     profilePictureUrl?: string;
   };
   currentUserId?: string;
+  source: FollowSource;
 }
 
-const UserListItem = ({ user, currentUserId }: UserListItemProps) => {
+const UserListItem = ({ user, currentUserId, source }: UserListItemProps) => {
   const router = useRouter();
   const isCurrentUser = currentUserId === user.id;
 
@@ -62,7 +64,7 @@ const UserListItem = ({ user, currentUserId }: UserListItemProps) => {
         <FollowButton
           targetUserId={user.id}
           compact={true}
-          source='followers_list'
+          source={source}
         />
       )}
     </TouchableOpacity>
@@ -159,7 +161,13 @@ export default function FollowersFollowingScreen() {
         data={data || []}
         keyExtractor={item => item.id}
         renderItem={({ item }) => (
-          <UserListItem user={item} currentUserId={currentUser?.id} />
+          <UserListItem
+            user={item}
+            currentUserId={currentUser?.id}
+            source={
+              activeTab === 'followers' ? 'followers_list' : 'following_list'
+            }
+          />
         )}
         ListEmptyComponent={renderEmpty}
         contentContainerStyle={

--- a/unify-front-end/app/followers-following.tsx
+++ b/unify-front-end/app/followers-following.tsx
@@ -58,7 +58,13 @@ const UserListItem = ({ user, currentUserId }: UserListItemProps) => {
         />
         <Text style={styles.username}>{user.username}</Text>
       </View>
-      {!isCurrentUser && <FollowButton targetUserId={user.id} compact={true} />}
+      {!isCurrentUser && (
+        <FollowButton
+          targetUserId={user.id}
+          compact={true}
+          source='followers_list'
+        />
+      )}
     </TouchableOpacity>
   );
 };

--- a/unify-front-end/components/AuthComponents/SignIn.tsx
+++ b/unify-front-end/components/AuthComponents/SignIn.tsx
@@ -82,7 +82,7 @@ export function SignIn({
     });
     if (error) {
       setErrorMessage('Invalid login credentials');
-      trackSignInFailed(error.code || 'signin_failed');
+      trackSignInFailed(error.code || 'signin_failed', 'email');
       setLoading(false);
       return;
     }
@@ -94,7 +94,7 @@ export function SignIn({
       });
     }
 
-    trackSignInCompleted();
+    trackSignInCompleted('email');
     setLoading(false);
   };
 
@@ -156,6 +156,7 @@ export function SignIn({
             queryKey: ['userInfo', data.user.id],
             queryFn: () => getUserInfo(data.user.id),
           });
+          trackSignInCompleted('google');
         } else if (data?.user?.id && !data?.user?.email) {
           setErrorMessage('Unable to retrieve email from Google account');
           setLoading(false);
@@ -226,6 +227,7 @@ export function SignIn({
             queryKey: ['userInfo', data.user.id],
             queryFn: () => getUserInfo(data.user.id),
           });
+          trackSignInCompleted('apple');
         } else if (data?.user?.id && !data?.user?.email) {
           setErrorMessage('Unable to retrieve email from Apple account');
           setLoading(false);

--- a/unify-front-end/components/AuthComponents/SignUp.tsx
+++ b/unify-front-end/components/AuthComponents/SignUp.tsx
@@ -46,6 +46,7 @@ export function SignUp({
     trackSignUpStarted,
     trackSignUpCompleted,
     trackSignUpFailed,
+    trackSignInCompleted,
     trackGoogleSignInUsed,
     trackAppleSignInUsed,
   } = useAnalytics();
@@ -130,7 +131,7 @@ export function SignUp({
         return;
       }
 
-      trackSignUpCompleted();
+      trackSignUpCompleted('email');
       const acceptedAt = new Date().toISOString();
       onShowOTP?.(normalizedEmail, password, acceptedAt);
       return;
@@ -193,6 +194,7 @@ export function SignUp({
             queryKey: ['userInfo', data.user.id],
             queryFn: () => getUserInfo(data.user.id),
           });
+          trackSignInCompleted('google');
         } else if (data?.user?.id && !data?.user?.email) {
           setErrorMessage('Unable to retrieve email from Google account');
           setLoading(false);
@@ -263,6 +265,7 @@ export function SignUp({
             queryKey: ['userInfo', data.user.id],
             queryFn: () => getUserInfo(data.user.id),
           });
+          trackSignInCompleted('apple');
         } else if (data?.user?.id && !data?.user?.email) {
           setErrorMessage('Unable to retrieve email from Apple account');
           setLoading(false);

--- a/unify-front-end/components/companion/StarterPrompts.tsx
+++ b/unify-front-end/components/companion/StarterPrompts.tsx
@@ -18,7 +18,11 @@ import {
 } from '@/utils/companionStarterHistory';
 
 interface StarterPromptsProps {
-  onPromptSelect: (prompt: string, mode?: string) => void;
+  onPromptSelect: (
+    prompt: string,
+    mode?: string,
+    isPersonalized?: boolean
+  ) => void;
   personalizedStarters?: PersonalizedStarter[];
 }
 
@@ -166,7 +170,7 @@ export const StarterPrompts: React.FC<StarterPromptsProps> = ({
 
   const handlePersonalizedPress = useCallback(
     (starter: PersonalizedStarter, slotIndex: number) => {
-      onPromptSelect(starter.prompt);
+      onPromptSelect(starter.prompt, undefined, true);
 
       // Persist; fire-and-forget. Concurrent calls are safe — markStarterSeen
       // serializes its own read-modify-write internally.
@@ -246,7 +250,7 @@ export const StarterPrompts: React.FC<StarterPromptsProps> = ({
           <TouchableOpacity
             key={card.id}
             style={styles.card}
-            onPress={() => onPromptSelect(card.prompt, card.mode)}
+            onPress={() => onPromptSelect(card.prompt, card.mode, false)}
             activeOpacity={0.8}
           >
             <View style={styles.cardHeader}>

--- a/unify-front-end/components/groups/GroupMemberRow.tsx
+++ b/unify-front-end/components/groups/GroupMemberRow.tsx
@@ -43,7 +43,9 @@ export default function GroupMemberRow({
         </View>
       </TouchableOpacity>
 
-      {!member.isFollowing && <FollowButton targetUserId={member.id} compact />}
+      {!member.isFollowing && (
+        <FollowButton targetUserId={member.id} compact source='community' />
+      )}
     </View>
   );
 }

--- a/unify-front-end/components/home/PostItem.tsx
+++ b/unify-front-end/components/home/PostItem.tsx
@@ -219,6 +219,9 @@ export const PostItem = memo(
       trackPostSave,
       trackPostUnsave,
       trackPostCommentOpened,
+      trackPostDeleted,
+      trackPostPinned,
+      trackPostUnpinned,
     } = useAnalytics();
 
     // Use batch-loaded metadata (no individual queries needed)
@@ -368,17 +371,22 @@ export const PostItem = memo(
       : content;
 
     const handlePinPost = () => {
+      const wasPinned = post.isPinned ?? false;
       pinPostMutation.mutate(
-        { postId: post.id, isPinned: post.isPinned ?? false },
+        { postId: post.id, isPinned: wasPinned },
         {
           onSuccess: () => {
+            if (wasPinned) {
+              trackPostUnpinned(String(post.id));
+            } else {
+              trackPostPinned(String(post.id));
+            }
             setDeleteModalVisible(false);
           },
           onError: error => {
             Alert.alert(
               'Error',
-              error.message ||
-                `Failed to ${post.isPinned ? 'unpin' : 'pin'} post`
+              error.message || `Failed to ${wasPinned ? 'unpin' : 'pin'} post`
             );
           },
         }
@@ -470,6 +478,7 @@ export const PostItem = memo(
             onPress: () => {
               deletePostMutation.mutate(post.id, {
                 onSuccess: () => {
+                  trackPostDeleted(String(post.id));
                   setDeleteModalVisible(false);
                 },
                 onError: error => {

--- a/unify-front-end/components/onboarding/OnboardingQuiz.tsx
+++ b/unify-front-end/components/onboarding/OnboardingQuiz.tsx
@@ -321,6 +321,11 @@ export default function OnboardingQuiz({
         capture(AnalyticsEvents.INVITE_REDEEMED, {
           source: inviteExtras?.inviteCode.source ?? 'manual',
         });
+        // Auto-follow happened server-side as part of redeem; emit a client-side
+        // signal so the referral funnel can include it without a server roundtrip.
+        capture(AnalyticsEvents.REFERRAL_AUTO_FOLLOW_COMPLETED, {
+          referrer_user_id: result.redeem.inviter.id,
+        });
         router.replace('/welcome-from-inviter' as any);
         return; // do NOT call onComplete; welcome screen handles its own dismiss
       }

--- a/unify-front-end/components/onboarding/OnboardingQuiz.tsx
+++ b/unify-front-end/components/onboarding/OnboardingQuiz.tsx
@@ -323,9 +323,13 @@ export default function OnboardingQuiz({
         });
         // Auto-follow happened server-side as part of redeem; emit a client-side
         // signal so the referral funnel can include it without a server roundtrip.
-        capture(AnalyticsEvents.REFERRAL_AUTO_FOLLOW_COMPLETED, {
-          referrer_user_id: result.redeem.inviter.id,
-        });
+        // Defensive: don't let a missing inviter id throw and abort the redeem flow.
+        const inviterId = result.redeem.inviter?.id;
+        if (inviterId) {
+          capture(AnalyticsEvents.REFERRAL_AUTO_FOLLOW_COMPLETED, {
+            referrer_user_id: inviterId,
+          });
+        }
         router.replace('/welcome-from-inviter' as any);
         return; // do NOT call onComplete; welcome screen handles its own dismiss
       }

--- a/unify-front-end/components/posts/CreatePostForm.tsx
+++ b/unify-front-end/components/posts/CreatePostForm.tsx
@@ -94,7 +94,7 @@ export default function CreatePostForm({
   const insets = useSafeAreaInsets();
 
   const { showToast } = useToast();
-  const { trackPostCreated } = useAnalytics();
+  const { trackPostCreated, trackPostFailed } = useAnalytics();
   const createPostMutation = useMutateCreatePost();
 
   const trimmedTitle = title.trim();
@@ -173,7 +173,7 @@ export default function CreatePostForm({
       },
       {
         onSuccess: (data: any) => {
-          if (data?.id) trackPostCreated(String(data.id));
+          trackPostCreated(data?.id ? String(data.id) : undefined);
           const postedToGroup = destination === 'group' && selectedGroup;
           const toastMessage = postedToGroup
             ? `Posted to ${selectedGroup.name}`
@@ -186,7 +186,13 @@ export default function CreatePostForm({
             group: groupToNavigate,
           });
         },
-        onError: _ => {
+        onError: (err: any) => {
+          trackPostFailed({
+            surface: 'create',
+            reason: err?.message,
+            ...(destination === 'group' &&
+              selectedGroup && { group_id: String(selectedGroup.id) }),
+          });
           Alert.alert('Error', 'Failed to create post. Please try again.');
         },
       }

--- a/unify-front-end/components/profile/FollowButton.tsx
+++ b/unify-front-end/components/profile/FollowButton.tsx
@@ -3,18 +3,22 @@ import { TouchableOpacity, Text, StyleSheet } from 'react-native';
 import { useFollowUser } from '@/hooks/users/useFollowUser';
 import { useFollowStatus } from '@/hooks/users/useFollowStatus';
 import { Theme } from '@/constants/Theme';
+import { useAnalytics, type FollowSource } from '@/utils/analytics';
 
 interface FollowButtonProps {
   targetUserId: string;
   compact?: boolean;
+  source?: FollowSource;
 }
 
 export const FollowButton = ({
   targetUserId,
   compact = false,
+  source = 'profile',
 }: FollowButtonProps) => {
   const { data: isFollowing } = useFollowStatus(targetUserId);
   const followUserMutation = useFollowUser();
+  const { trackUserFollowed, trackUserUnfollowed } = useAnalytics();
 
   // Local state to track follow status for immediate UI updates
   const [localIsFollowing, setLocalIsFollowing] = useState<boolean | null>(
@@ -29,13 +33,25 @@ export const FollowButton = ({
   }, [isFollowing]);
 
   const handleFollowToggle = () => {
+    const willFollow = !localIsFollowing;
     // Immediately update local state for instant UI feedback
-    setLocalIsFollowing(!localIsFollowing);
+    setLocalIsFollowing(willFollow);
 
-    followUserMutation.mutate({
-      targetUserId,
-      isFollowing: !localIsFollowing,
-    });
+    followUserMutation.mutate(
+      {
+        targetUserId,
+        isFollowing: willFollow,
+      },
+      {
+        onSuccess: () => {
+          if (willFollow) {
+            trackUserFollowed({ target_user_id: targetUserId, source });
+          } else {
+            trackUserUnfollowed({ target_user_id: targetUserId, source });
+          }
+        },
+      }
+    );
   };
 
   return (

--- a/unify-front-end/components/profile/Profile.tsx
+++ b/unify-front-end/components/profile/Profile.tsx
@@ -6,7 +6,8 @@ import {
   FlatList,
   Alert,
 } from 'react-native';
-import { useState, memo, useCallback, useMemo } from 'react';
+import { useState, memo, useCallback, useMemo, useEffect } from 'react';
+import { useAnalytics } from '@/utils/analytics';
 import { ProfileHeader } from '@/components/profile/ProfileHeader';
 import FeedWithHook from '@/components/FeedWithHook';
 import EmptyFeedMessage from '@/components/profile/EmptyFeedMessage';
@@ -74,6 +75,15 @@ export default function Profile({ userId, initialTab }: ProfileProps) {
   const { blockMutation, unblockMutation } = useMutateBlockUser();
   const [activeTab, setActiveTab] = useState(initialTab || 'Posts');
   const { showToast } = useToast();
+  const { trackProfileViewed } = useAnalytics();
+
+  useEffect(() => {
+    if (!userId) return;
+    trackProfileViewed({
+      profile_user_id: userId,
+      is_self: isCurrentUser,
+    });
+  }, [userId, isCurrentUser, trackProfileViewed]);
 
   // Create data array with header, tabs, and feed content to be used to do sticky header
   const data = useMemo(

--- a/unify-front-end/components/profile/Profile.tsx
+++ b/unify-front-end/components/profile/Profile.tsx
@@ -6,7 +6,7 @@ import {
   FlatList,
   Alert,
 } from 'react-native';
-import { useState, memo, useCallback, useMemo, useEffect } from 'react';
+import { useState, memo, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useAnalytics } from '@/utils/analytics';
 import { ProfileHeader } from '@/components/profile/ProfileHeader';
 import FeedWithHook from '@/components/FeedWithHook';
@@ -59,9 +59,10 @@ interface ProfileProps {
 }
 
 export default function Profile({ userId, initialTab }: ProfileProps) {
-  const { currentUser } = useCurrentUser();
+  const { currentUser, isLoading: isLoadingCurrentUser } = useCurrentUser();
+  const currentUserId = currentUser?.id;
   const { data: userInfo } = useUserInfo(userId);
-  const isCurrentUser = currentUser?.id === userId;
+  const isCurrentUser = currentUserId === userId;
   const router = useRouter();
   const usePostsFeedHook = useCallback(useUserPosts.bind(null, userId), [
     userId,
@@ -76,14 +77,20 @@ export default function Profile({ userId, initialTab }: ProfileProps) {
   const [activeTab, setActiveTab] = useState(initialTab || 'Posts');
   const { showToast } = useToast();
   const { trackProfileViewed } = useAnalytics();
+  const trackedProfileRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!userId) return;
+    // Wait for current user to resolve before firing — otherwise is_self can
+    // briefly be false (during load) and then true once currentUser arrives,
+    // producing duplicate/mislabeled profile_viewed events.
+    if (!userId || isLoadingCurrentUser) return;
+    if (trackedProfileRef.current === userId) return;
     trackProfileViewed({
       profile_user_id: userId,
-      is_self: isCurrentUser,
+      is_self: userId === currentUserId,
     });
-  }, [userId, isCurrentUser, trackProfileViewed]);
+    trackedProfileRef.current = userId;
+  }, [userId, currentUserId, isLoadingCurrentUser, trackProfileViewed]);
 
   // Create data array with header, tabs, and feed content to be used to do sticky header
   const data = useMemo(

--- a/unify-front-end/hooks/posts/useMutateCreateComment.ts
+++ b/unify-front-end/hooks/posts/useMutateCreateComment.ts
@@ -2,10 +2,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createComment } from '@/services/posts/createComment';
 import { useInvalidatePostMetadata } from '@/hooks/usePostMetadata';
 import { updatePostAcrossCaches } from '@/utils/updatePostCaches';
+import { useAnalytics } from '@/utils/analytics';
 
 export const useMutateCreateComment = () => {
   const queryClient = useQueryClient();
   const { invalidatePostMetadata } = useInvalidatePostMetadata();
+  const { trackCommentCreated, trackMutationFailed } = useAnalytics();
 
   return useMutation({
     mutationFn: async ({
@@ -20,7 +22,7 @@ export const useMutateCreateComment = () => {
       return await createComment(postId, content, parentCommentId);
     },
 
-    onSuccess: (_, { postId }) => {
+    onSuccess: (data: any, { postId, content, parentCommentId }) => {
       updatePostAcrossCaches(queryClient, postId, post => ({
         ...post,
         commentCount: (post.commentCount ?? 0) + 1,
@@ -37,10 +39,24 @@ export const useMutateCreateComment = () => {
 
       // Invalidate only the specific post's metadata (more efficient)
       invalidatePostMetadata(postId);
+
+      trackCommentCreated({
+        post_id: String(postId),
+        comment_id: data?.id ? String(data.id) : undefined,
+        is_reply: parentCommentId != null,
+        ...(parentCommentId != null && {
+          parent_comment_id: String(parentCommentId),
+        }),
+        body_length: content.length,
+      });
     },
 
-    onError: error => {
+    onError: (error: any) => {
       console.error('Error creating comment:', error);
+      trackMutationFailed({
+        surface: 'comment_create',
+        error_message: error?.message,
+      });
     },
   });
 };

--- a/unify-front-end/hooks/posts/useMutateDeleteComment.ts
+++ b/unify-front-end/hooks/posts/useMutateDeleteComment.ts
@@ -1,10 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteComment } from '@/services/posts/deleteComment';
 import { useInvalidatePostMetadata } from '@/hooks/usePostMetadata';
+import { useAnalytics } from '@/utils/analytics';
 
 export const useMutateDeleteComment = () => {
   const queryClient = useQueryClient();
   const { invalidatePostMetadata } = useInvalidatePostMetadata();
+  const { trackCommentDeleted } = useAnalytics();
 
   return useMutation({
     mutationFn: async ({
@@ -16,7 +18,7 @@ export const useMutateDeleteComment = () => {
     }) => {
       return await deleteComment(commentId);
     },
-    onSuccess: (_, { postId }) => {
+    onSuccess: (_, { postId, commentId }) => {
       // Invalidate comments for the post
       queryClient.invalidateQueries({ queryKey: ['post-comments', postId] });
 
@@ -27,6 +29,11 @@ export const useMutateDeleteComment = () => {
       queryClient.invalidateQueries({ queryKey: ['feed', 'forYou'] });
       queryClient.invalidateQueries({ queryKey: ['feed', 'following'] });
       queryClient.invalidateQueries({ queryKey: ['feed', 'groups'] });
+
+      trackCommentDeleted({
+        comment_id: String(commentId),
+        post_id: String(postId),
+      });
     },
     onError: error => {
       console.error('Error deleting comment:', error);

--- a/unify-front-end/hooks/posts/useMutateLikeComment.ts
+++ b/unify-front-end/hooks/posts/useMutateLikeComment.ts
@@ -1,8 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { likeComment, unlikeComment } from '@/services/posts/likeComment';
+import { useAnalytics } from '@/utils/analytics';
 
 export const useMutateLikeComment = () => {
   const queryClient = useQueryClient();
+  const { trackCommentLiked, trackCommentUnliked } = useAnalytics();
 
   return useMutation({
     mutationFn: async ({
@@ -35,6 +37,14 @@ export const useMutateLikeComment = () => {
         return await unlikeComment(commentId);
       } else {
         return await likeComment(commentId);
+      }
+    },
+    onSuccess: (_, { commentId, isLiked }) => {
+      // isLiked is the PRE-toggle state, so the new state is the inverse.
+      if (isLiked) {
+        trackCommentUnliked({ comment_id: String(commentId) });
+      } else {
+        trackCommentLiked({ comment_id: String(commentId) });
       }
     },
     onError: err => {

--- a/unify-front-end/hooks/referrals/useInvite.ts
+++ b/unify-front-end/hooks/referrals/useInvite.ts
@@ -36,7 +36,7 @@ interface UseInviteResult {
 export function useInvite(): UseInviteResult {
   const { currentUser } = useCurrentUser();
   const { data: profile } = useOnboardingProfile(currentUser?.id);
-  const { capture } = useAnalytics();
+  const { capture, trackInviteShareCompleted } = useAnalytics();
   const [inviting, setInviting] = useState(false);
 
   const userId = currentUser?.id ?? null;
@@ -92,13 +92,26 @@ export function useInvite(): UseInviteResult {
         // PostHog already has the user's distinct_id; the inviter↔invitee
         // join lives in the referrals table server-side.
         capture(AnalyticsEvents.INVITE_SHARE_SHEET_OPENED, { shared: true });
+        trackInviteShareCompleted({
+          result: 'sent',
+          activity_type:
+            'activityType' in result ? (result.activityType ?? null) : null,
+        });
+      } else if (result.action === Share.dismissedAction) {
+        trackInviteShareCompleted({ result: 'dismissed' });
       }
     } catch (err) {
       console.error('useInvite: Share failed', err);
     } finally {
       setInviting(false);
     }
-  }, [codeQuery.data, currentUser?.username, profile?.city, capture]);
+  }, [
+    codeQuery.data,
+    currentUser?.username,
+    profile?.city,
+    capture,
+    trackInviteShareCompleted,
+  ]);
 
   return {
     code: codeQuery.data ?? null,

--- a/unify-front-end/hooks/usePushNotifications.ts
+++ b/unify-front-end/hooks/usePushNotifications.ts
@@ -7,6 +7,7 @@ import {
   registerForPushNotifications,
   addNotificationResponseListener,
 } from '@/services/push/pushNotifications';
+import { useAnalytics } from '@/utils/analytics';
 import type { Subscription } from 'expo-notifications';
 
 /**
@@ -23,6 +24,12 @@ export function usePushNotifications() {
   const { currentUser } = useCurrentUser();
   const router = useRouter();
   const responseListenerRef = useRef<Subscription>(null);
+  const {
+    trackPushPermissionPrompted,
+    trackPushPermissionGranted,
+    trackPushPermissionDenied,
+    trackNotificationOpened,
+  } = useAnalytics();
 
   // Clear badge count when app comes to foreground
   useEffect(() => {
@@ -42,21 +49,39 @@ export function usePushNotifications() {
     // Always register for push — social notifications always send.
     // Users control notification preferences via iOS/Android system settings.
     // The wants_reminders toggle only controls learn reminders (server-side).
-    registerForPushNotifications().catch(err => {
-      console.error('Push notification registration failed:', err);
-    });
+    registerForPushNotifications()
+      .then(result => {
+        if (result.permission === 'unsupported') return;
+        if (result.prompted) {
+          trackPushPermissionPrompted({ prompted_in: 'in_app' });
+          if (result.permission === 'granted') {
+            trackPushPermissionGranted({ prompted_in: 'in_app' });
+          } else {
+            trackPushPermissionDenied({ prompted_in: 'in_app' });
+          }
+        }
+      })
+      .catch(err => {
+        console.error('Push notification registration failed:', err);
+      });
 
     // Handle notification taps
     responseListenerRef.current = addNotificationResponseListener(response => {
       const data = response.notification.request.content.data;
+      const notificationType =
+        typeof data?.type === 'string' ? data.type : 'unknown';
+
+      let deepLinkTarget: string | null = null;
 
       // Navigate based on notification type (with circle_id validation)
       if (data?.type === 'circle_matched' && isValidCircleId(data?.circle_id)) {
+        deepLinkTarget = '/community-matching/circle';
         router.push(`/community-matching/circle/${data.circle_id}` as const);
       } else if (
         data?.type === 'circle_ending_soon' &&
         isValidCircleId(data?.circle_id)
       ) {
+        deepLinkTarget = '/community-matching/circle/chat';
         router.push(
           `/community-matching/circle/${data.circle_id}/chat` as const
         );
@@ -64,6 +89,7 @@ export function usePushNotifications() {
         data?.type === 'new_message' &&
         isValidCircleId(data?.circle_id)
       ) {
+        deepLinkTarget = '/community-matching/circle/chat';
         router.push(
           `/community-matching/circle/${data.circle_id}/chat` as const
         );
@@ -74,11 +100,13 @@ export function usePushNotifications() {
           data?.type === 'comment_reply') &&
         data?.post_id != null
       ) {
+        deepLinkTarget = '/post-details';
         router.push({
           pathname: '/post-details',
           params: { postId: String(data.post_id) },
         } as Href);
       } else if (data?.type === 'followed' && data?.actor_user_id != null) {
+        deepLinkTarget = '/profile';
         router.push({
           pathname: '/profile',
           params: { userId: String(data.actor_user_id) },
@@ -89,6 +117,7 @@ export function usePushNotifications() {
         data?.submodule_id &&
         data?.module_id
       ) {
+        deepLinkTarget = '/(tabs)/Learn/lesson';
         router.push({
           pathname:
             '/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]',
@@ -99,6 +128,8 @@ export function usePushNotifications() {
           },
         } as Href);
       }
+
+      trackNotificationOpened(notificationType, deepLinkTarget);
     });
 
     return () => {

--- a/unify-front-end/hooks/users/useMutateBlockUser.ts
+++ b/unify-front-end/hooks/users/useMutateBlockUser.ts
@@ -2,9 +2,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { blockUser } from '@/services/users/blockUser';
 import { unblockUser } from '@/services/users/unblockUser';
 import { invalidateBlockedUserIds } from '@/services/users/getBlockedUserIds';
+import { useAnalytics } from '@/utils/analytics';
 
 export const useMutateBlockUser = () => {
   const queryClient = useQueryClient();
+  const { trackUserBlocked, trackUserUnblocked } = useAnalytics();
 
   const invalidateAll = () => {
     invalidateBlockedUserIds();
@@ -14,12 +16,18 @@ export const useMutateBlockUser = () => {
 
   const blockMutation = useMutation({
     mutationFn: (blockedUserId: string) => blockUser(blockedUserId),
-    onSuccess: () => invalidateAll(),
+    onSuccess: (_, blockedUserId) => {
+      invalidateAll();
+      trackUserBlocked(blockedUserId);
+    },
   });
 
   const unblockMutation = useMutation({
     mutationFn: (blockedUserId: string) => unblockUser(blockedUserId),
-    onSuccess: () => invalidateAll(),
+    onSuccess: (_, blockedUserId) => {
+      invalidateAll();
+      trackUserUnblocked(blockedUserId);
+    },
   });
 
   return { blockMutation, unblockMutation };

--- a/unify-front-end/services/push/pushNotifications.ts
+++ b/unify-front-end/services/push/pushNotifications.ts
@@ -13,30 +13,52 @@ Notifications.setNotificationHandler({
   }),
 });
 
+export interface PushRegistrationResult {
+  token: string | null;
+  /** Permission status BEFORE we asked (used to detect first-prompt). */
+  previousPermission: Notifications.PermissionStatus | 'unsupported';
+  /** Permission status AFTER our request (or existing if no request was made). */
+  permission: Notifications.PermissionStatus | 'unsupported';
+  /** True iff we actually showed the system prompt this call. */
+  prompted: boolean;
+}
+
 /**
  * Register for push notifications and store the token in Supabase.
- * Returns the Expo push token if successful, null otherwise.
+ * Returns a result describing the permission flow + the token (when granted).
  */
-export async function registerForPushNotifications(): Promise<string | null> {
+export async function registerForPushNotifications(): Promise<PushRegistrationResult> {
   // Push notifications only work on physical devices
   if (!Device.isDevice) {
     console.warn('[Push] Skipped: not a physical device');
-    return null;
+    return {
+      token: null,
+      previousPermission: 'unsupported',
+      permission: 'unsupported',
+      prompted: false,
+    };
   }
 
   // Check existing permission status
   const { status: existingStatus } = await Notifications.getPermissionsAsync();
   let finalStatus = existingStatus;
+  let prompted = false;
 
   // Request permission if not already granted
   if (existingStatus !== 'granted') {
     const { status } = await Notifications.requestPermissionsAsync();
     finalStatus = status;
+    prompted = true;
   }
 
   if (finalStatus !== 'granted') {
     console.warn('[Push] Skipped: permission not granted, status:', finalStatus);
-    return null;
+    return {
+      token: null,
+      previousPermission: existingStatus,
+      permission: finalStatus,
+      prompted,
+    };
   }
 
   // Create Android notification channels
@@ -74,12 +96,22 @@ export async function registerForPushNotifications(): Promise<string | null> {
 
     if (!user) {
       console.warn('[Push] No authenticated user, skipping token storage');
-      return token;
+      return {
+        token,
+        previousPermission: existingStatus,
+        permission: finalStatus,
+        prompted,
+      };
     }
 
     if (!token) {
       console.warn('[Push] Token is empty, skipping storage');
-      return null;
+      return {
+        token: null,
+        previousPermission: existingStatus,
+        permission: finalStatus,
+        prompted,
+      };
     }
 
     // First try to update existing token for this user on this platform
@@ -126,10 +158,20 @@ export async function registerForPushNotifications(): Promise<string | null> {
       }
     }
 
-    return token;
+    return {
+      token,
+      previousPermission: existingStatus,
+      permission: finalStatus,
+      prompted,
+    };
   } catch (error) {
     console.error('[Push] Registration failed:', error);
-    return null;
+    return {
+      token: null,
+      previousPermission: existingStatus,
+      permission: finalStatus,
+      prompted,
+    };
   }
 }
 

--- a/unify-front-end/supabase/functions/rag-query/index.ts
+++ b/unify-front-end/supabase/functions/rag-query/index.ts
@@ -879,21 +879,29 @@ Deno.serve(async (req: Request) => {
     };
     const estimatedCostUsd = llmResult.usage.costUsd;
 
-    // Send $ai_generation event to PostHog LLM analytics
-    captureAiGeneration(effectiveUserId || 'anonymous', {
-      $ai_model: llmResult.model,
-      $ai_provider: llmResult.provider,
-      $ai_input_tokens: tokenUsage.prompt_tokens,
-      $ai_output_tokens: tokenUsage.completion_tokens,
-      $ai_total_tokens: tokenUsage.total_tokens,
-      $ai_total_cost_usd: estimatedCostUsd,
-      $ai_trace_id: conversationIdentifier || undefined,
-      // Custom properties for filtering
-      feature: 'ai_companion',
-      query_type: queryType,
-      has_sources: sources.length > 0,
-      response_time_ms: stageTimings.generation_ms,
-    });
+    // Send $ai_generation event to PostHog LLM analytics — only when we have a
+    // real user id, so the LLM cost dashboards aren't polluted with an
+    // 'anonymous' bucket. Without a user we just skip the capture.
+    if (effectiveUserId) {
+      captureAiGeneration(effectiveUserId, {
+        $ai_model: llmResult.model,
+        $ai_provider: llmResult.provider,
+        $ai_input_tokens: tokenUsage.prompt_tokens,
+        $ai_output_tokens: tokenUsage.completion_tokens,
+        $ai_total_tokens: tokenUsage.total_tokens,
+        $ai_total_cost_usd: estimatedCostUsd,
+        $ai_trace_id: conversationIdentifier || undefined,
+        // Custom properties for filtering
+        feature: 'ai_companion',
+        query_type: queryType,
+        has_sources: sources.length > 0,
+        response_time_ms: stageTimings.generation_ms,
+      });
+    } else {
+      console.warn(
+        'rag-query: skipping $ai_generation capture — no effectiveUserId'
+      );
+    }
 
     // Store token usage outside the response critical path.
     if (effectiveUserId && tokenUsage.total_tokens > 0) {

--- a/unify-front-end/supabase/functions/rag-query/index.ts
+++ b/unify-front-end/supabase/functions/rag-query/index.ts
@@ -879,29 +879,22 @@ Deno.serve(async (req: Request) => {
     };
     const estimatedCostUsd = llmResult.usage.costUsd;
 
-    // Send $ai_generation event to PostHog LLM analytics — only when we have a
-    // real user id, so the LLM cost dashboards aren't polluted with an
-    // 'anonymous' bucket. Without a user we just skip the capture.
-    if (effectiveUserId) {
-      captureAiGeneration(effectiveUserId, {
-        $ai_model: llmResult.model,
-        $ai_provider: llmResult.provider,
-        $ai_input_tokens: tokenUsage.prompt_tokens,
-        $ai_output_tokens: tokenUsage.completion_tokens,
-        $ai_total_tokens: tokenUsage.total_tokens,
-        $ai_total_cost_usd: estimatedCostUsd,
-        $ai_trace_id: conversationIdentifier || undefined,
-        // Custom properties for filtering
-        feature: 'ai_companion',
-        query_type: queryType,
-        has_sources: sources.length > 0,
-        response_time_ms: stageTimings.generation_ms,
-      });
-    } else {
-      console.warn(
-        'rag-query: skipping $ai_generation capture — no effectiveUserId'
-      );
-    }
+    // Send $ai_generation event to PostHog LLM analytics. effectiveUserId is
+    // guaranteed non-null here — unauthenticated requests already 401'd above.
+    captureAiGeneration(effectiveUserId, {
+      $ai_model: llmResult.model,
+      $ai_provider: llmResult.provider,
+      $ai_input_tokens: tokenUsage.prompt_tokens,
+      $ai_output_tokens: tokenUsage.completion_tokens,
+      $ai_total_tokens: tokenUsage.total_tokens,
+      $ai_total_cost_usd: estimatedCostUsd,
+      $ai_trace_id: conversationIdentifier || undefined,
+      // Custom properties for filtering
+      feature: 'ai_companion',
+      query_type: queryType,
+      has_sources: sources.length > 0,
+      response_time_ms: stageTimings.generation_ms,
+    });
 
     // Store token usage outside the response critical path.
     if (effectiveUserId && tokenUsage.total_tokens > 0) {

--- a/unify-front-end/utils/analytics.ts
+++ b/unify-front-end/utils/analytics.ts
@@ -267,6 +267,7 @@ export type FollowSource =
   | 'invite_auto_follow'
   | 'search'
   | 'followers_list'
+  | 'following_list'
   | 'community';
 
 export interface FollowProperties {

--- a/unify-front-end/utils/analytics.ts
+++ b/unify-front-end/utils/analytics.ts
@@ -3,9 +3,6 @@ import { usePostHog } from 'posthog-react-native';
 
 // Event name constants for type safety and consistency
 export const AnalyticsEvents = {
-  // Screen views
-  SCREEN_VIEWED: 'screen_viewed',
-
   // Tab navigation
   TAB_SWITCHED: 'tab_switched',
 
@@ -16,6 +13,33 @@ export const AnalyticsEvents = {
   POST_UNSAVED: 'post_unsaved',
   POST_COMMENT_OPENED: 'post_comment_opened',
   POST_CREATED: 'post_created',
+  POST_DELETED: 'post_deleted',
+  POST_PINNED: 'post_pinned',
+  POST_UNPINNED: 'post_unpinned',
+  POST_FAILED: 'post_failed',
+
+  // Comments
+  COMMENT_CREATED: 'comment_created',
+  COMMENT_LIKED: 'comment_liked',
+  COMMENT_UNLIKED: 'comment_unliked',
+  COMMENT_DELETED: 'comment_deleted',
+  REPLY_PILL_TAPPED: 'reply_pill_tapped',
+
+  // Follow / profile
+  USER_FOLLOWED: 'user_followed',
+  USER_UNFOLLOWED: 'user_unfollowed',
+  PROFILE_VIEWED: 'profile_viewed',
+  PROFILE_PICTURE_UPDATED: 'profile_picture_updated',
+  PROFILE_EDITED: 'profile_edited',
+
+  // Block / safety
+  USER_BLOCKED: 'user_blocked',
+  USER_UNBLOCKED: 'user_unblocked',
+
+  // Push permissions
+  PUSH_PERMISSION_PROMPTED: 'push_permission_prompted',
+  PUSH_PERMISSION_GRANTED: 'push_permission_granted',
+  PUSH_PERMISSION_DENIED: 'push_permission_denied',
 
   // Groups
   GROUP_JOINED: 'group_joined',
@@ -54,6 +78,8 @@ export const AnalyticsEvents = {
   SIGN_IN_FAILED: 'sign_in_failed',
   GOOGLE_SIGN_IN_USED: 'google_sign_in_used',
   APPLE_SIGN_IN_USED: 'apple_sign_in_used',
+  USER_SIGNED_OUT: 'user_signed_out',
+  ACCOUNT_DELETED: 'account_deleted',
 
   // Search
   SEARCH_OPENED: 'search_opened',
@@ -89,6 +115,8 @@ export const AnalyticsEvents = {
 
   // AI Companion (extended)
   COMPANION_RESPONSE_RECEIVED: 'companion_response_received',
+  COMPANION_FEEDBACK_GIVEN: 'companion_feedback_given',
+  COMPANION_CHIP_REFRESHED: 'companion_chip_refreshed',
 
   // Daily Tips
   TIP_VIEWED: 'tip_viewed',
@@ -98,10 +126,15 @@ export const AnalyticsEvents = {
   INVITE_CODE_GENERATED: 'invite_code_generated',
   INVITE_SCREEN_OPENED: 'invite_screen_opened',
   INVITE_SHARE_SHEET_OPENED: 'invite_share_sheet_opened',
+  INVITE_SHARE_COMPLETED: 'invite_share_completed',
   INVITE_CODE_DETECTED_FROM_CLIPBOARD: 'invite_code_detected_from_clipboard',
   INVITE_REDEEMED: 'invite_redeemed',
   INVITE_REDEEM_FAILED: 'invite_redeem_failed',
   INVITE_GROUPS_JOINED_AT_SIGNUP: 'invite_groups_joined_at_signup',
+  REFERRAL_AUTO_FOLLOW_COMPLETED: 'referral_auto_follow_completed',
+
+  // Errors
+  MUTATION_FAILED: 'mutation_failed',
 } as const;
 
 export type AnalyticsEventName =
@@ -197,12 +230,95 @@ export interface TipViewedProperties {
   date: string;
 }
 
+export interface IdentifyUserProperties {
+  email?: string | null;
+  username?: string | null;
+  persona?: string | null;
+  is_premium?: boolean;
+  city?: string | null;
+  province?: string | null;
+  arrival_date?: string | null;
+  stage?: number | null;
+}
+
+export type AuthMethod = 'email' | 'google' | 'apple';
+
+export interface AuthCompletedProperties {
+  method: AuthMethod;
+}
+
+export interface CommentCreatedProperties {
+  post_id: string;
+  comment_id?: string;
+  is_reply: boolean;
+  parent_comment_id?: string;
+  body_length: number;
+}
+
+export interface CommentInteractionProperties {
+  comment_id: string;
+  post_id?: string;
+  is_reply?: boolean;
+}
+
+export type FollowSource =
+  | 'profile'
+  | 'feed'
+  | 'invite_auto_follow'
+  | 'search'
+  | 'followers_list'
+  | 'community';
+
+export interface FollowProperties {
+  target_user_id: string;
+  source: FollowSource;
+}
+
+export interface ProfileViewedProperties {
+  profile_user_id: string;
+  is_self: boolean;
+}
+
+export interface PushPermissionProperties {
+  prompted_in?: 'onboarding' | 'in_app' | 'system';
+}
+
+export interface PostFailedProperties {
+  surface: 'create' | 'delete' | 'pin' | 'unpin';
+  reason?: string;
+  group_id?: string;
+}
+
+export interface MutationFailedProperties {
+  surface: string;
+  error_message?: string;
+  error_code?: string;
+}
+
+export interface CompanionFeedbackProperties {
+  message_id?: string;
+  rating: 'up' | 'down';
+}
+
+export interface InviteShareCompletedProperties {
+  result: 'sent' | 'dismissed' | 'unknown';
+  activity_type?: string | null;
+}
+
 // Hook for analytics tracking
 export function useAnalytics() {
   const posthog = usePostHog();
 
   return useMemo(
     () => ({
+      // Identity
+      identify: (userId: string, properties: IdentifyUserProperties) => {
+        posthog?.identify(userId, { ...properties });
+      },
+      reset: () => {
+        posthog?.reset();
+      },
+
       // Screen tracking
       trackScreen: (screenName: string) => {
         posthog?.screen(screenName);
@@ -234,8 +350,130 @@ export function useAnalytics() {
           post_id: postId,
         });
       },
-      trackPostCreated: (postId: string) => {
-        posthog?.capture(AnalyticsEvents.POST_CREATED, { post_id: postId });
+      trackPostCreated: (postId?: string) => {
+        posthog?.capture(AnalyticsEvents.POST_CREATED, {
+          ...(postId && { post_id: postId }),
+          post_id_known: !!postId,
+        });
+      },
+      trackPostDeleted: (postId: string) => {
+        posthog?.capture(AnalyticsEvents.POST_DELETED, { post_id: postId });
+      },
+      trackPostPinned: (postId: string) => {
+        posthog?.capture(AnalyticsEvents.POST_PINNED, { post_id: postId });
+      },
+      trackPostUnpinned: (postId: string) => {
+        posthog?.capture(AnalyticsEvents.POST_UNPINNED, { post_id: postId });
+      },
+      trackPostFailed: (properties: PostFailedProperties) => {
+        posthog?.capture(AnalyticsEvents.POST_FAILED, { ...properties });
+      },
+
+      // Comments
+      trackCommentCreated: (properties: CommentCreatedProperties) => {
+        posthog?.capture(AnalyticsEvents.COMMENT_CREATED, { ...properties });
+      },
+      trackCommentLiked: (properties: CommentInteractionProperties) => {
+        posthog?.capture(AnalyticsEvents.COMMENT_LIKED, { ...properties });
+      },
+      trackCommentUnliked: (properties: CommentInteractionProperties) => {
+        posthog?.capture(AnalyticsEvents.COMMENT_UNLIKED, { ...properties });
+      },
+      trackCommentDeleted: (properties: CommentInteractionProperties) => {
+        posthog?.capture(AnalyticsEvents.COMMENT_DELETED, { ...properties });
+      },
+      trackReplyPillTapped: (parentCommentId: string) => {
+        posthog?.capture(AnalyticsEvents.REPLY_PILL_TAPPED, {
+          parent_comment_id: parentCommentId,
+        });
+      },
+
+      // Follow / profile
+      trackUserFollowed: (properties: FollowProperties) => {
+        posthog?.capture(AnalyticsEvents.USER_FOLLOWED, { ...properties });
+      },
+      trackUserUnfollowed: (properties: FollowProperties) => {
+        posthog?.capture(AnalyticsEvents.USER_UNFOLLOWED, { ...properties });
+      },
+      trackProfileViewed: (properties: ProfileViewedProperties) => {
+        posthog?.capture(AnalyticsEvents.PROFILE_VIEWED, { ...properties });
+      },
+      trackProfilePictureUpdated: () => {
+        posthog?.capture(AnalyticsEvents.PROFILE_PICTURE_UPDATED);
+      },
+      trackProfileEdited: (field: string) => {
+        posthog?.capture(AnalyticsEvents.PROFILE_EDITED, { field });
+      },
+
+      // Block / safety
+      trackUserBlocked: (targetUserId: string) => {
+        posthog?.capture(AnalyticsEvents.USER_BLOCKED, {
+          target_user_id: targetUserId,
+        });
+      },
+      trackUserUnblocked: (targetUserId: string) => {
+        posthog?.capture(AnalyticsEvents.USER_UNBLOCKED, {
+          target_user_id: targetUserId,
+        });
+      },
+
+      // Push permissions
+      trackPushPermissionPrompted: (properties?: PushPermissionProperties) => {
+        posthog?.capture(AnalyticsEvents.PUSH_PERMISSION_PROMPTED, {
+          ...(properties ?? {}),
+        });
+      },
+      trackPushPermissionGranted: (properties?: PushPermissionProperties) => {
+        posthog?.capture(AnalyticsEvents.PUSH_PERMISSION_GRANTED, {
+          ...(properties ?? {}),
+        });
+      },
+      trackPushPermissionDenied: (properties?: PushPermissionProperties) => {
+        posthog?.capture(AnalyticsEvents.PUSH_PERMISSION_DENIED, {
+          ...(properties ?? {}),
+        });
+      },
+
+      // Account lifecycle
+      trackUserSignedOut: (reason?: string) => {
+        posthog?.capture(
+          AnalyticsEvents.USER_SIGNED_OUT,
+          reason ? { reason } : {}
+        );
+      },
+      trackAccountDeleted: () => {
+        posthog?.capture(AnalyticsEvents.ACCOUNT_DELETED);
+      },
+
+      // Companion (extended)
+      trackCompanionFeedbackGiven: (
+        properties: CompanionFeedbackProperties
+      ) => {
+        posthog?.capture(AnalyticsEvents.COMPANION_FEEDBACK_GIVEN, {
+          ...properties,
+        });
+      },
+      trackCompanionChipRefreshed: () => {
+        posthog?.capture(AnalyticsEvents.COMPANION_CHIP_REFRESHED);
+      },
+
+      // Referrals (extended)
+      trackInviteShareCompleted: (
+        properties: InviteShareCompletedProperties
+      ) => {
+        posthog?.capture(AnalyticsEvents.INVITE_SHARE_COMPLETED, {
+          ...properties,
+        });
+      },
+      trackReferralAutoFollowCompleted: (referrerUserId: string) => {
+        posthog?.capture(AnalyticsEvents.REFERRAL_AUTO_FOLLOW_COMPLETED, {
+          referrer_user_id: referrerUserId,
+        });
+      },
+
+      // Errors
+      trackMutationFailed: (properties: MutationFailedProperties) => {
+        posthog?.capture(AnalyticsEvents.MUTATION_FAILED, { ...properties });
       },
 
       // Group interactions
@@ -284,10 +522,15 @@ export function useAnalytics() {
           message_length: messageLength,
         });
       },
-      trackCompanionStarterPromptUsed: (prompt: string, mode?: string) => {
+      trackCompanionStarterPromptUsed: (
+        prompt: string,
+        mode?: string,
+        isPersonalized?: boolean
+      ) => {
         posthog?.capture(AnalyticsEvents.COMPANION_STARTER_PROMPT_USED, {
           prompt,
           ...(mode && { mode }),
+          ...(isPersonalized !== undefined && { is_personalized: isPersonalized }),
         });
       },
       trackCompanionSuggestionClicked: (suggestion: string) => {
@@ -395,20 +638,21 @@ export function useAnalytics() {
       trackSignUpStarted: () => {
         posthog?.capture(AnalyticsEvents.SIGN_UP_STARTED);
       },
-      trackSignUpCompleted: () => {
-        posthog?.capture(AnalyticsEvents.SIGN_UP_COMPLETED);
+      trackSignUpCompleted: (method: AuthMethod = 'email') => {
+        posthog?.capture(AnalyticsEvents.SIGN_UP_COMPLETED, { method });
       },
       trackSignUpFailed: (errorType: string) => {
         posthog?.capture(AnalyticsEvents.SIGN_UP_FAILED, {
           error_type: errorType,
         });
       },
-      trackSignInCompleted: () => {
-        posthog?.capture(AnalyticsEvents.SIGN_IN_COMPLETED);
+      trackSignInCompleted: (method: AuthMethod = 'email') => {
+        posthog?.capture(AnalyticsEvents.SIGN_IN_COMPLETED, { method });
       },
-      trackSignInFailed: (errorType: string) => {
+      trackSignInFailed: (errorType: string, method: AuthMethod = 'email') => {
         posthog?.capture(AnalyticsEvents.SIGN_IN_FAILED, {
           error_type: errorType,
+          method,
         });
       },
       trackGoogleSignInUsed: (authType: 'sign_up' | 'sign_in') => {
@@ -488,9 +732,13 @@ export function useAnalytics() {
       },
 
       // Notifications
-      trackNotificationOpened: (notificationType: string) => {
+      trackNotificationOpened: (
+        notificationType: string,
+        deepLinkTarget?: string | null
+      ) => {
         posthog?.capture(AnalyticsEvents.NOTIFICATION_OPENED, {
           notification_type: notificationType,
+          ...(deepLinkTarget && { deep_link_target: deepLinkTarget }),
         });
       },
       trackNotificationsMarkAllRead: (count: number) => {


### PR DESCRIPTION
## Summary

Comprehensive analytics audit + remediation. Found via live PostHog query that **0 `$identify` events fired in 30 days** — every install was an anonymous UUID with NULL email/persona, invalidating retention/funnel analyses. Also caught `post_created` firing 0 times (RLS gotcha hiding the returned id) and `sign_in_completed` firing 0 times on OAuth paths.

Three logical commits:

**1. Identify foundation + auth surfaces** (`feat(analytics): identify users in PostHog and add auth event surfaces`)
- `posthog.identify()` wired in `AppContent` on session change with email, username, persona, is_premium, city, province, arrival_date
- `posthog.reset()` automatic when session goes null
- `user_signed_out` and `account_deleted` events
- `trackSignInCompleted({ method })` now fires on Apple + Google OAuth success paths (was 0 events for 30 days)
- ~25 new event constants added; dead `SCREEN_VIEWED` constant removed

**2. Social loop, push permission, post lifecycle** (`feat(analytics): instrument social loop, push permission, post lifecycle`)
- `post_created` now fires `onSuccess` regardless of returned id (with `post_id_known` flag); `post_failed` on error; `post_deleted/pinned/unpinned`
- `comment_created` (with `is_reply`, `parent_comment_id`, `body_length`), `comment_liked/unliked/deleted`
- `user_followed/unfollowed` with `source` prop (`profile`, `followers_list`, `community`)
- `profile_viewed` on Profile mount
- `user_blocked/unblocked` from `useMutateBlockUser`
- `push_permission_prompted/granted/denied` — `registerForPushNotifications` now returns a result object so the hook knows whether the system prompt fired
- `notification_opened` extended with `deep_link_target`

**3. Companion + referrals + edge fn** (`chore(analytics): companion personalization flag, referral attribution, edge fn cleanup`)
- `companion_starter_prompt_used` gains `is_personalized` flag — distinguish dynamic personalized chips from static topic cards
- `invite_share_completed` fires on `Share.share` resolution with `activity_type`
- `referral_auto_follow_completed` fires on successful redeem with `referrer_user_id`, closing the referral funnel
- `supabase/functions/rag-query`: dropped `'anonymous'` fallback for `$ai_generation` — already deployed to Supabase (v91, ACTIVE)

## Pre-deploy verification done

- TypeScript: clean
- Jest: 87 tests pass, 8 suites
- Edge function deployed to Supabase (v91, ACTIVE)
- ClickUp ticket [86ah5u7wu](https://app.clickup.com/t/86ah5u7wu) filed for the underlying RLS issue

## PostHog dashboards (created via MCP)

- [Activation Funnel](https://us.posthog.com/project/250953/dashboard/1523047)
- [Social Loop](https://us.posthog.com/project/250953/dashboard/1523048)
- [Referrals Funnel](https://us.posthog.com/project/250953/dashboard/1523049)

These will populate once this PR ships and users start firing events on the new instrumentation.

## Test plan

- [ ] Sign up fresh → check PostHog Persons → confirm a Supabase-id-based person with email/username
- [ ] Run `SELECT countIf(event = '$identify') FROM events WHERE timestamp > now() - INTERVAL 1 DAY` → expect > 0
- [ ] Sign out, sign in as a different user on the same device → confirm two distinct PostHog persons
- [ ] Create a post → confirm `post_created` fires within 30s in Live Events
- [ ] Sign in via Apple and Google → confirm `sign_in_completed` with `method` property
- [ ] Comment on a post (top-level + reply) → confirm `comment_created` with correct `is_reply`
- [ ] Follow a user → confirm `user_followed` with `source`
- [ ] Block a user → confirm `user_blocked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Companion starter prompts now support personalized prompts.

* **Chores**
  * Expanded analytics across sign-in/sign-up, account lifecycle (sign-out, deletion), posts/comments (create/delete/pin/unpin/failures), follows/blocks/profile views, invites/shares/referrals, push notification prompts/opens, and in-app interactions to improve product insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->