### PR TITLE
feat(companion): raise free AI message limit from 3 to 6

### DIFF
--- a/unify-front-end/app/(tabs)/companion/index.tsx
+++ b/unify-front-end/app/(tabs)/companion/index.tsx
@@ -46,7 +46,7 @@ import { usePersonalizedStarters } from '@/hooks/companion/usePersonalizedStarte
 import { AICompanionBusyError } from '@/utils/gemini';
 import { useToast } from '@/context/ToastContext';
 
-const MESSAGE_LIMIT = 3;
+const MESSAGE_LIMIT = 6;
 const OPTIMISTIC_MESSAGE_MATCH_WINDOW_MS = 5000;
 const { width: windowWidth, height: windowHeight } = Dimensions.get('window');
 const dottedLineTopOffset = -windowHeight * 0.001;


### PR DESCRIPTION
## Summary
- Bumps the cap on free AI Companion messages from 3 to 6 by changing `MESSAGE_LIMIT` in `app/(tabs)/companion/index.tsx`.
- Premium users are unaffected (gate is `isPremium || messagesLeft > 0`).
- Server-side `DAILY_MESSAGE_LIMIT = 30` in `supabase/functions/rag-query/index.ts` is unchanged and still bounds the per-user daily quota above this client cap.

## Test plan
- [ ] Sign in as a non-premium user; confirm the messages-left indicator starts at 6 and decrements per send.
- [ ] Send 6 messages; confirm the input/send button locks out on the 7th and shows the upsell.
- [ ] Sign in as a premium user; confirm no cap is applied.
- [ ] Confirm reset behavior (daily/period rollover) still restores the counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the message limit for non-premium users, allowing more messages before the send action becomes disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->