### PR TITLE
fix: auth refresh noise, Trans key warning, pre-login language persistence

### DIFF
--- a/unify-front-end/app/_layout.tsx
+++ b/unify-front-end/app/_layout.tsx
@@ -12,9 +12,11 @@ import { useTranslation } from 'react-i18next';
 import {
   i18nReady,
   setStoredLanguage,
+  hasUserPickedLanguageThisSession,
   SUPPORTED_LANGUAGES,
   type SupportedLanguage,
 } from '@/i18n';
+import { supabase } from '@/lib/supabase';
 import { useOnboardingProfile } from '@/hooks/onboarding/useOnboardingProfile';
 import AuthWrapper from '@/components/AuthComponents/AuthWrapper';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -220,9 +222,14 @@ function useAnalyticsIdentitySync() {
 }
 
 /**
- * On first authed mount, if the user's preferred_language stored in Supabase
- * differs from the local i18n language, switch local to match. Lets users keep
- * their language across devices/reinstalls. One-shot per session.
+ * On first authed mount, reconcile local i18n language with the user's
+ * preferred_language in Supabase. Direction depends on whether the user
+ * actively picked a language during this session:
+ *   - User picked (pre-login picker, account-settings) → push local to server.
+ *     Their just-made choice wins, and propagates to other devices.
+ *   - No explicit pick → pull server to local. Cross-device sync preserved
+ *     (returning users with stale AsyncStorage get the correct language).
+ * One-shot per user-id per session.
  */
 function useLanguageSyncFromSupabase() {
   const { currentUser } = useCurrentUser();
@@ -234,14 +241,27 @@ function useLanguageSyncFromSupabase() {
   useEffect(() => {
     if (!currentUser?.id || !profile) return;
     if (syncedForUserRef.current === currentUser.id) return;
+    syncedForUserRef.current = currentUser.id;
+
     const remote = profile.preferred_language;
-    if (remote && remote !== i18n.language && remote in SUPPORTED_LANGUAGES) {
-      syncedForUserRef.current = currentUser.id;
-      setStoredLanguage(remote as SupportedLanguage).catch(e =>
-        console.error('Failed to sync language from supabase:', e)
+    const local = i18n.language as SupportedLanguage;
+
+    if (hasUserPickedLanguageThisSession()) {
+      if (local && local in SUPPORTED_LANGUAGES && local !== remote) {
+        supabase
+          .from('user_onboarding_profiles')
+          .update({ preferred_language: local })
+          .eq('id', currentUser.id)
+          .then(({ error }) => {
+            if (error) {
+              console.error('Failed to push language to supabase:', error);
+            }
+          });
+      }
+    } else if (remote && remote in SUPPORTED_LANGUAGES && remote !== local) {
+      setStoredLanguage(remote as SupportedLanguage, { source: 'server' }).catch(
+        e => console.error('Failed to sync language from supabase:', e)
       );
-    } else if (remote) {
-      syncedForUserRef.current = currentUser.id;
     }
   }, [currentUser?.id, profile, i18n.language]);
 }

--- a/unify-front-end/components/AuthComponents/LegalConsentModal.tsx
+++ b/unify-front-end/components/AuthComponents/LegalConsentModal.tsx
@@ -116,6 +116,7 @@ export default function LegalConsentModal({
                   components={{
                     terms: (
                       <Text
+                        key='terms'
                         style={styles.linkText}
                         onPress={() => openDocument('termsOfService')}
                         accessibilityRole='link'
@@ -124,6 +125,7 @@ export default function LegalConsentModal({
                     ),
                     privacy: (
                       <Text
+                        key='privacy'
                         style={styles.linkText}
                         onPress={() => openDocument('privacyPolicy')}
                         accessibilityRole='link'
@@ -132,6 +134,7 @@ export default function LegalConsentModal({
                     ),
                     guidelines: (
                       <Text
+                        key='guidelines'
                         style={styles.linkText}
                         onPress={() => openDocument('communityGuidelines')}
                         accessibilityRole='link'

--- a/unify-front-end/components/AuthComponents/SignIn.tsx
+++ b/unify-front-end/components/AuthComponents/SignIn.tsx
@@ -450,12 +450,14 @@ export function SignIn({
             components={{
               terms: (
                 <Text
+                  key='terms'
                   style={styles.legalLink}
                   onPress={() => Linking.openURL(LEGAL_URLS.termsOfService)}
                 />
               ),
               privacy: (
                 <Text
+                  key='privacy'
                   style={styles.legalLink}
                   onPress={() => Linking.openURL(LEGAL_URLS.privacyPolicy)}
                 />

--- a/unify-front-end/components/AuthComponents/SignUp.tsx
+++ b/unify-front-end/components/AuthComponents/SignUp.tsx
@@ -447,6 +447,7 @@ export function SignUp({
               components={{
                 terms: (
                   <Text
+                    key='terms'
                     style={styles.checkboxLinkText}
                     onPress={() => setWebViewDoc('termsOfService')}
                     accessibilityRole='link'
@@ -455,6 +456,7 @@ export function SignUp({
                 ),
                 privacy: (
                   <Text
+                    key='privacy'
                     style={styles.checkboxLinkText}
                     onPress={() => setWebViewDoc('privacyPolicy')}
                     accessibilityRole='link'
@@ -463,6 +465,7 @@ export function SignUp({
                 ),
                 guidelines: (
                   <Text
+                    key='guidelines'
                     style={styles.checkboxLinkText}
                     onPress={() => setWebViewDoc('communityGuidelines')}
                     accessibilityRole='link'

--- a/unify-front-end/context/UserContext.tsx
+++ b/unify-front-end/context/UserContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, use, useEffect, useState } from 'react';
+import { isAuthApiError } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabase';
 import { useUserInfo } from '@/hooks/users/useUserInfo';
 import { useQueryClient } from '@tanstack/react-query';
@@ -42,17 +43,32 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   // Get user ID and email from auth
   useEffect(() => {
     const getAuthUser = async () => {
-      const { data } = await supabase.auth.getUser();
-      if (data?.user) {
-        setUserId(data.user.id);
-        setUserEmail(data.user.email || null);
-      } else {
-        setUserId(null);
-        setUserEmail(null);
+      try {
+        const { data } = await supabase.auth.getUser();
+        if (data?.user) {
+          setUserId(data.user.id);
+          setUserEmail(data.user.email || null);
+        } else {
+          setUserId(null);
+          setUserEmail(null);
+        }
+      } catch (err) {
+        // Stale session in SecureStore (e.g. refresh token rotated, expired,
+        // or invalidated server-side). Clear it locally so subsequent calls
+        // return a clean null user and stop throwing on every app launch.
+        if (isAuthApiError(err) && err.code === 'refresh_token_not_found') {
+          await supabase.auth.signOut({ scope: 'local' });
+          setUserId(null);
+          setUserEmail(null);
+          return;
+        }
+        throw err;
       }
     };
 
-    getAuthUser();
+    getAuthUser().catch(err => {
+      console.error('[UserContext] Failed to load auth user:', err);
+    });
 
     // Listen for auth changes
     const {

--- a/unify-front-end/i18n/index.ts
+++ b/unify-front-end/i18n/index.ts
@@ -19,6 +19,17 @@ export type SupportedLanguage = keyof typeof SUPPORTED_LANGUAGES;
 
 const LANGUAGE_STORAGE_KEY = 'user_preferred_language';
 
+// In-memory flag — set when the *user* actively picks a language during this
+// app session (pre-login picker, account-settings). Lets the post-login sync
+// hook tell apart "user just chose this" from "AsyncStorage value left over
+// from a previous run." Resets on cold start so cross-device server-wins
+// behavior is preserved when nobody has explicitly picked yet this session.
+let userPickedLanguageThisSession = false;
+
+export function hasUserPickedLanguageThisSession(): boolean {
+  return userPickedLanguageThisSession;
+}
+
 async function getStoredLanguage(): Promise<SupportedLanguage> {
   try {
     const stored = await AsyncStorage.getItem(LANGUAGE_STORAGE_KEY);
@@ -39,8 +50,14 @@ async function getStoredLanguage(): Promise<SupportedLanguage> {
   return 'en';
 }
 
-export async function setStoredLanguage(lang: SupportedLanguage) {
+export async function setStoredLanguage(
+  lang: SupportedLanguage,
+  opts: { source: 'user' | 'server' } = { source: 'user' }
+) {
   await AsyncStorage.setItem(LANGUAGE_STORAGE_KEY, lang);
+  if (opts.source === 'user') {
+    userPickedLanguageThisSession = true;
+  }
   await i18n.changeLanguage(lang);
 }
 


### PR DESCRIPTION
## Summary

Three independent bug fixes from a debugging session, each isolated to its own commit.

**Auth — stale refresh-token noise** (`f9c70c6f`)
`context/UserContext.tsx` fired `supabase.auth.getUser()` unawaited with no `.catch()`, so any expired or rotated refresh token surfaced as an unhandled promise rejection on every app launch. Caught the specific `AuthApiError` with code `refresh_token_not_found`, cleared the corrupted local session via `signOut({ scope: 'local' })`, and let the existing auth state listener route the user to welcome cleanly. The app behavior was already fine — this just stops polluting Metro logs and prevents the same stale token from re-throwing on every subsequent `getUser()` call elsewhere.

**Auth — `<Trans>` missing key warning** (`3891c276`)
React 19 enforces key warnings more strictly than 18. `react-i18next@14`'s `<Trans>` interpolates named tags by `cloneElement`-ing the elements you pass via `components={{...}}`, and `cloneElement` preserves the source key. None of the `<Text>` elements had keys, so the resulting array of children rendered without keys. Added `key='terms'` / `key='privacy'` / `key='guidelines'` on the legal links in `SignIn`, `SignUp`, and `LegalConsentModal`.

**i18n — pre-login language pick reverts after sign-in** (`771ac87d`)
Picking Vietnamese (or any non-English language) on the welcome / sign-in / sign-up screens did not persist after authentication — the app reverted to English (or the server's stored value). `useLanguageSyncFromSupabase` in `app/_layout.tsx` always treated server as the source of truth on first authed mount, overwriting the user's just-made local choice. It had no way to tell apart "user actively just picked this" from "stale `AsyncStorage` value from a previous run."

Fix introduces an in-memory `userPickedLanguageThisSession` flag in `i18n/index.ts`, set only on user-sourced `setStoredLanguage` calls (pre-login picker, account-settings). The sync hook now branches:
- Flag set → push local to Supabase. User's choice wins and propagates across devices.
- Flag unset → keep the existing server-wins behavior so cross-device sync still works for returning users on a fresh install.

## Test plan
- [x] TypeScript check passes (`npx tsc --noEmit -p .`) — no errors in any of the 6 changed files
- [ ] Manual: launch app, confirm no `refresh_token_not_found` stack trace in Metro logs
- [ ] Manual: navigate to SignIn, confirm no React key warning for the legal text
- [ ] Manual: pick Vietnamese on welcome screen → sign up → confirm app stays Vietnamese, Supabase `user_onboarding_profiles.preferred_language` shows `vi`
- [ ] Manual: pick Vietnamese on welcome screen → sign in as existing user → same expectation
- [ ] Manual: returning user on fresh install (no AsyncStorage), Supabase has `preferred_language='vi'` → sign in → confirm app pulls Vietnamese from server (cross-device sync still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication errors when refresh tokens expire, preventing repeated failures on app launch
  * Enhanced React rendering stability in authentication screens

* **New Features**
  * Language preferences now sync more reliably between local settings and server, maintaining consistency across sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->