### PR TITLE
feat(interviews): weekly founder-interview picker pipeline

### DIFF
--- a/unify-front-end/supabase/functions/_shared/interview/email-templates.test.ts
+++ b/unify-front-end/supabase/functions/_shared/interview/email-templates.test.ts
@@ -1,0 +1,107 @@
+// supabase/functions/_shared/interview/email-templates.test.ts
+import { assertEquals, assertStringIncludes } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import {
+  renderOutboundEmail,
+  renderApprovalEmail,
+  renderUnsubscribeConfirmation,
+  renderInfoPage,
+} from './email-templates.ts';
+
+Deno.test('renderOutboundEmail uses first name when present', () => {
+  const out = renderOutboundEmail({
+    recipientName: 'Mei Lin',
+    calComLink: 'https://cal.com/savar/20min',
+    unsubscribeUrl: 'https://example.com/unsub?token=abc',
+    businessAddress: '123 Main St, Vancouver BC',
+  });
+  assertStringIncludes(out.html, 'Hi Mei,');
+  assertStringIncludes(out.text, 'Hi Mei,');
+  assertEquals(out.subject, "Quick question from Unify's founder");
+});
+
+Deno.test('renderOutboundEmail falls back to "there" when name is missing', () => {
+  const out = renderOutboundEmail({
+    recipientName: null,
+    calComLink: 'https://cal.com/savar/20min',
+    unsubscribeUrl: 'https://example.com/unsub?token=abc',
+    businessAddress: '123 Main St',
+  });
+  assertStringIncludes(out.html, 'Hi there,');
+});
+
+Deno.test('renderOutboundEmail includes CASL footer (address + unsub)', () => {
+  const out = renderOutboundEmail({
+    recipientName: 'Alex',
+    calComLink: 'https://cal.com/savar/20min',
+    unsubscribeUrl: 'https://example.com/unsub?token=abc',
+    businessAddress: '123 Main St, Vancouver BC',
+  });
+  assertStringIncludes(out.html, '123 Main St, Vancouver BC');
+  assertStringIncludes(out.html, 'https://example.com/unsub?token=abc');
+});
+
+Deno.test('renderOutboundEmail HTML-escapes the recipient name', () => {
+  const out = renderOutboundEmail({
+    recipientName: '<script>alert(1)</script>',
+    calComLink: 'https://cal.com/savar/20min',
+    unsubscribeUrl: 'https://example.com/unsub',
+    businessAddress: '123 Main St',
+  });
+  assertEquals(out.html.includes('<script>'), false);
+  assertStringIncludes(out.html, '&lt;script&gt;');
+});
+
+Deno.test('renderApprovalEmail lists each candidate with their per-link buttons', () => {
+  const out = renderApprovalEmail({
+    candidates: [
+      {
+        email: 'a@e.com', name: 'Alice', tier: 'C',
+        surfaces14d: 4, events14d: 25, companionMsgs14d: 8,
+        userCreatedAt: '2026-01-21',
+        emailSubject: 'Quick question from Unify\'s founder',
+        emailBodyExcerpt: 'Hi Alice,\n\nI\'m Savar...',
+        approveUrl: 'https://x/approve?token=1',
+        skipUrl: 'https://x/skip?token=1',
+      },
+    ],
+    pipelineHealth: { cTier: 5, bTier: 14, inCooldown: 12 },
+    warning: null,
+  });
+  assertStringIncludes(out.subject, '1 candidate');
+  assertStringIncludes(out.html, 'a@e.com');
+  assertStringIncludes(out.html, 'Tier C');
+  assertStringIncludes(out.html, 'https://x/approve?token=1');
+  assertStringIncludes(out.html, 'https://x/skip?token=1');
+  assertStringIncludes(out.html, '5 C-tier');
+});
+
+Deno.test('renderApprovalEmail handles zero candidates', () => {
+  const out = renderApprovalEmail({
+    candidates: [],
+    pipelineHealth: { cTier: 0, bTier: 0, inCooldown: 0 },
+    warning: null,
+  });
+  assertStringIncludes(out.subject, '0 candidate');
+  assertStringIncludes(out.html, 'No eligible candidates');
+});
+
+Deno.test('renderApprovalEmail surfaces missed-run warning when present', () => {
+  const out = renderApprovalEmail({
+    candidates: [],
+    pipelineHealth: { cTier: 0, bTier: 0, inCooldown: 0 },
+    warning: 'Last successful pick was 11 days ago — previous run may have failed silently',
+  });
+  assertStringIncludes(out.html, '11 days ago');
+});
+
+Deno.test('renderUnsubscribeConfirmation returns valid HTML', () => {
+  const html = renderUnsubscribeConfirmation();
+  assertStringIncludes(html, '<html');
+  assertStringIncludes(html, 'unsubscribed');
+});
+
+Deno.test('renderInfoPage shows the provided message', () => {
+  const html = renderInfoPage('Approval link expired.');
+  assertStringIncludes(html, 'Approval link expired.');
+  assertStringIncludes(html, '<html');
+});

--- a/unify-front-end/supabase/functions/_shared/interview/email-templates.ts
+++ b/unify-front-end/supabase/functions/_shared/interview/email-templates.ts
@@ -1,0 +1,161 @@
+// supabase/functions/_shared/interview/email-templates.ts
+import type { Tier } from './selection.ts';
+
+export interface Rendered { subject: string; html: string; text: string }
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function firstName(full: string | null): string {
+  if (!full) return 'there';
+  const first = full.trim().split(/\s+/)[0];
+  return first || 'there';
+}
+
+// ---------- Outbound (to candidate) ----------
+
+export interface OutboundOpts {
+  recipientName: string | null;
+  calComLink: string;
+  unsubscribeUrl: string;
+  businessAddress: string;
+}
+
+export function renderOutboundEmail(o: OutboundOpts): Rendered {
+  const name = escapeHtml(firstName(o.recipientName));
+  const cal = escapeHtml(o.calComLink);
+  const unsub = escapeHtml(o.unsubscribeUrl);
+  const addr = escapeHtml(o.businessAddress);
+
+  const subject = "Quick question from Unify's founder";
+
+  const text =
+`Hi ${name},
+
+I'm Savar, one of the co-founders of Unify. You've been one of our most active users this month — thank you, genuinely.
+
+Would you be open to a 20-minute call with me? No agenda, no sales pitch — I just want to hear what's working, what's broken, and what you wish we'd build.
+
+If that sounds good, pick any time that works:
+${o.calComLink}
+
+If not, no worries at all.
+
+Thanks for being one of our early users,
+
+Savar Gupta
+Co-founder, Unify
+
+—
+You're receiving this because you've been actively using the Unify app.
+${o.businessAddress} · Unsubscribe: ${o.unsubscribeUrl}
+`;
+
+  const html =
+`<!doctype html><html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:560px;margin:0 auto;padding:24px;color:#1a1a1a;line-height:1.5">
+<p>Hi ${name},</p>
+<p>I'm Savar, one of the co-founders of Unify. You've been one of our most active users this month — thank you, genuinely.</p>
+<p>Would you be open to a 20-minute call with me? No agenda, no sales pitch — I just want to hear what's working, what's broken, and what you wish we'd build.</p>
+<p>If that sounds good, pick any time that works:<br>
+<a href="${cal}">${cal}</a></p>
+<p>If not, no worries at all.</p>
+<p>Thanks for being one of our early users,</p>
+<p>Savar Gupta<br>Co-founder, Unify</p>
+<hr style="border:none;border-top:1px solid #e5e5e5;margin:32px 0 12px">
+<p style="font-size:11px;color:#888;line-height:1.4">
+You're receiving this because you've been actively using the Unify app.<br>
+${addr} · <a href="${unsub}" style="color:#888">Unsubscribe</a>
+</p>
+</body></html>`;
+
+  return { subject, html, text };
+}
+
+// ---------- Approval (to Savar) ----------
+
+export interface ApprovalCandidate {
+  email: string;
+  name: string | null;
+  tier: Tier;
+  surfaces14d: number;
+  events14d: number;
+  companionMsgs14d: number;
+  userCreatedAt: string;       // pre-formatted display date
+  emailSubject: string;
+  emailBodyExcerpt: string;    // ~first 200 chars of text body
+  approveUrl: string;
+  skipUrl: string;
+}
+
+export interface ApprovalOpts {
+  candidates: ApprovalCandidate[];
+  pipelineHealth: { cTier: number; bTier: number; inCooldown: number };
+  warning: string | null;
+}
+
+export function renderApprovalEmail(o: ApprovalOpts): Rendered {
+  const n = o.candidates.length;
+  const subject = `[Unify Picker] ${n} candidate${n === 1 ? '' : 's'} ready for this week`;
+
+  const warningBlock = o.warning
+    ? `<div style="background:#fff3cd;border:1px solid #ffeaa7;padding:12px;margin-bottom:16px;border-radius:4px">⚠ ${escapeHtml(o.warning)}</div>`
+    : '';
+
+  const bodyBlock = n === 0
+    ? `<p>No eligible candidates this week.</p>`
+    : o.candidates.map((c, i) => candidateCard(c, i + 1)).join('\n');
+
+  const health = o.pipelineHealth;
+  const healthLine = `<p style="font-size:12px;color:#666;margin-top:24px">Pipeline health: ${health.cTier} C-tier · ${health.bTier} B-tier · ${health.inCooldown} in cooldown</p>`;
+
+  const html =
+`<!doctype html><html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:680px;margin:0 auto;padding:24px;color:#1a1a1a;line-height:1.5">
+<p>Hey Savar,</p>
+<p>This week's picker pulled ${n} candidate${n === 1 ? '' : 's'}. Click Approve &amp; Send on each, or Skip to pass. Anything left untouched by next Sunday auto-expires.</p>
+${warningBlock}
+${bodyBlock}
+${healthLine}
+<p style="font-size:11px;color:#888;margin-top:32px">— Unify Picker (auto-generated)</p>
+</body></html>`;
+
+  const text = `${n} candidate(s) ready. Open the HTML version to approve each — links require HTML.`;
+  return { subject, html, text };
+}
+
+function candidateCard(c: ApprovalCandidate, idx: number): string {
+  const label = c.name ? `${escapeHtml(c.name)} &lt;${escapeHtml(c.email)}&gt;` : escapeHtml(c.email);
+  const intensity = c.companionMsgs14d ? ` · ${c.companionMsgs14d} companion msgs` : '';
+  return `<div style="border-top:1px solid #e5e5e5;padding:16px 0">
+<p style="margin:0 0 4px"><strong>${idx}. ${label}</strong> &nbsp;(Tier ${c.tier})</p>
+<p style="margin:0 0 4px;font-size:13px;color:#555">Active on ${c.surfaces14d} surfaces · ${c.events14d} events${intensity}</p>
+<p style="margin:0 0 12px;font-size:13px;color:#555">User since: ${escapeHtml(c.userCreatedAt)}</p>
+<div style="background:#f7f7f7;border-radius:4px;padding:12px;font-size:13px;white-space:pre-wrap;font-family:ui-monospace,SFMono-Regular,Menlo,monospace">Subject: ${escapeHtml(c.emailSubject)}
+
+${escapeHtml(c.emailBodyExcerpt)}</div>
+<p style="margin:16px 0 0">
+  <a href="${escapeHtml(c.approveUrl)}" style="background:#0a7;color:#fff;text-decoration:none;padding:10px 18px;border-radius:4px;font-weight:600;margin-right:8px">Approve &amp; Send →</a>
+  <a href="${escapeHtml(c.skipUrl)}" style="background:#eee;color:#333;text-decoration:none;padding:10px 18px;border-radius:4px;font-weight:600">Skip →</a>
+</p>
+</div>`;
+}
+
+// ---------- Static HTML response pages ----------
+
+export function renderUnsubscribeConfirmation(): string {
+  return `<!doctype html><html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:480px;margin:64px auto;padding:24px;text-align:center;color:#1a1a1a">
+<h1 style="font-size:20px;margin:0 0 12px">You've been unsubscribed</h1>
+<p>You won't receive any more research emails from Unify. Thanks for using the app.</p>
+</body></html>`;
+}
+
+export function renderInfoPage(message: string): string {
+  return `<!doctype html><html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;max-width:480px;margin:64px auto;padding:24px;text-align:center;color:#1a1a1a">
+<p>${escapeHtml(message)}</p>
+</body></html>`;
+}

--- a/unify-front-end/supabase/functions/_shared/interview/posthog.test.ts
+++ b/unify-front-end/supabase/functions/_shared/interview/posthog.test.ts
@@ -1,0 +1,78 @@
+// supabase/functions/_shared/interview/posthog.test.ts
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { fetchActiveUsers14d, type ActiveUser } from './posthog.ts';
+
+Deno.test('fetchActiveUsers14d posts HogQL to the configured endpoint', async () => {
+  let captured: { url?: string; init?: RequestInit } = {};
+  const stubFetch: typeof fetch = async (url, init) => {
+    captured = { url: String(url), init };
+    return new Response(JSON.stringify({
+      results: [
+        ['p1', 'a@example.com', 'Alice', 3, 12, 6],
+        ['p2', 'b@example.com', 'Bob',   2, 4,  0],
+      ],
+    }), { status: 200 });
+  };
+
+  const users = await fetchActiveUsers14d({
+    posthogHost: 'https://us.i.posthog.com',
+    projectId: '250953',
+    apiKey: 'phx_test',
+    fetchImpl: stubFetch,
+  });
+
+  assertEquals(captured.url, 'https://us.i.posthog.com/api/projects/250953/query/');
+  assertEquals(captured.init?.method, 'POST');
+  const body = JSON.parse(String(captured.init?.body));
+  assertEquals(body.query.kind, 'HogQLQuery');
+  assertEquals(typeof body.query.query, 'string');
+  assertEquals(body.query.query.includes('INTERVAL 14 DAY'), true);
+
+  assertEquals(users.length, 2);
+  const alice: ActiveUser = users[0];
+  assertEquals(alice.personId, 'p1');
+  assertEquals(alice.email, 'a@example.com');
+  assertEquals(alice.name, 'Alice');
+  assertEquals(alice.surfaces14d, 3);
+  assertEquals(alice.events14d, 12);
+  assertEquals(alice.companionMsgs14d, 6);
+});
+
+Deno.test('fetchActiveUsers14d throws on non-2xx response', async () => {
+  const stubFetch: typeof fetch = async () =>
+    new Response('{"detail":"unauthorized"}', { status: 401 });
+
+  let threw = false;
+  try {
+    await fetchActiveUsers14d({
+      posthogHost: 'https://us.i.posthog.com',
+      projectId: '250953',
+      apiKey: 'bad',
+      fetchImpl: stubFetch,
+    });
+  } catch (e) {
+    threw = true;
+    assertEquals(String(e).includes('401'), true);
+  }
+  assertEquals(threw, true);
+});
+
+Deno.test('fetchActiveUsers14d skips rows with null email', async () => {
+  const stubFetch: typeof fetch = async () =>
+    new Response(JSON.stringify({
+      results: [
+        ['p1', 'a@example.com', 'Alice', 3, 12, 6],
+        ['p2', null,            null,    2, 4,  0],
+      ],
+    }), { status: 200 });
+
+  const users = await fetchActiveUsers14d({
+    posthogHost: 'https://us.i.posthog.com',
+    projectId: '250953',
+    apiKey: 'phx_test',
+    fetchImpl: stubFetch,
+  });
+
+  assertEquals(users.length, 1);
+  assertEquals(users[0].email, 'a@example.com');
+});

--- a/unify-front-end/supabase/functions/_shared/interview/posthog.ts
+++ b/unify-front-end/supabase/functions/_shared/interview/posthog.ts
@@ -1,0 +1,94 @@
+// supabase/functions/_shared/interview/posthog.ts
+export interface ActiveUser {
+  personId: string;
+  email: string;
+  name: string | null;
+  surfaces14d: number;
+  events14d: number;
+  companionMsgs14d: number;
+}
+
+export interface FetchActiveUsersOpts {
+  posthogHost: string;   // e.g. https://us.i.posthog.com
+  projectId: string;     // PostHog project id, e.g. "250953"
+  apiKey: string;        // Personal API key with project read scope
+  fetchImpl?: typeof fetch;
+}
+
+const HOGQL = `
+WITH surface_events AS (
+  SELECT
+    person_id,
+    person.properties.email AS email,
+    person.properties.name  AS name,
+    multiIf(
+      event IN ('post_created','post_liked','comment_created','post_saved','comment_liked','post_unliked','post_unsaved'),
+        'feed',
+      event IN ('companion_message_sent','companion_starter_prompt_used','companion_suggestion_clicked','companion_history_viewed'),
+        'companion',
+      event IN ('lesson_page_viewed','quiz_completed','lesson_ask_ai_used','lesson_highlight_created','lesson_highlight_removed','module_viewed','module_card_clicked'),
+        'learn',
+      event IN ('group_joined','group_viewed','group_left'),
+        'groups',
+      event IN ('checklist_task_completed','checklist_task_uncompleted'),
+        'checklist',
+      NULL
+    ) AS surface,
+    event,
+    timestamp
+  FROM events
+  WHERE timestamp >= now() - INTERVAL 14 DAY
+    AND event IN (
+      'post_created','post_liked','comment_created','post_saved','comment_liked','post_unliked','post_unsaved',
+      'companion_message_sent','companion_starter_prompt_used','companion_suggestion_clicked','companion_history_viewed',
+      'lesson_page_viewed','quiz_completed','lesson_ask_ai_used','lesson_highlight_created','lesson_highlight_removed','module_viewed','module_card_clicked',
+      'group_joined','group_viewed','group_left',
+      'checklist_task_completed','checklist_task_uncompleted'
+    )
+)
+SELECT
+  person_id,
+  email,
+  name,
+  count(DISTINCT surface) AS surfaces_14d,
+  count() AS events_14d,
+  countIf(event = 'companion_message_sent') AS companion_msgs_14d
+FROM surface_events
+WHERE surface IS NOT NULL
+GROUP BY person_id, email, name
+HAVING surfaces_14d >= 2
+LIMIT 500
+`.trim();
+
+export async function fetchActiveUsers14d(
+  opts: FetchActiveUsersOpts,
+): Promise<ActiveUser[]> {
+  const f = opts.fetchImpl ?? fetch;
+  const res = await f(`${opts.posthogHost}/api/projects/${opts.projectId}/query/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type':  'application/json',
+      'Authorization': `Bearer ${opts.apiKey}`,
+    },
+    body: JSON.stringify({ query: { kind: 'HogQLQuery', query: HOGQL } }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`PostHog query failed: ${res.status} ${text}`);
+  }
+  const data = await res.json() as { results: unknown[][] };
+  const out: ActiveUser[] = [];
+  for (const row of data.results ?? []) {
+    const [personId, email, name, surfaces14d, events14d, companionMsgs14d] = row;
+    if (typeof email !== 'string' || !email) continue;
+    out.push({
+      personId: String(personId),
+      email,
+      name: typeof name === 'string' ? name : null,
+      surfaces14d: Number(surfaces14d),
+      events14d: Number(events14d),
+      companionMsgs14d: Number(companionMsgs14d),
+    });
+  }
+  return out;
+}

--- a/unify-front-end/supabase/functions/_shared/interview/selection.test.ts
+++ b/unify-front-end/supabase/functions/_shared/interview/selection.test.ts
@@ -1,0 +1,95 @@
+// supabase/functions/_shared/interview/selection.test.ts
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import {
+  classifyTier,
+  pickCandidates,
+  type Candidate,
+} from './selection.ts';
+import type { ActiveUser } from './posthog.ts';
+
+function u(over: Partial<ActiveUser> = {}): ActiveUser {
+  return {
+    personId: 'p',
+    email: 'x@e.com',
+    name: 'X',
+    surfaces14d: 2,
+    events14d: 5,
+    companionMsgs14d: 0,
+    ...over,
+  };
+}
+
+Deno.test('classifyTier returns C for >=3 surfaces', () => {
+  assertEquals(classifyTier(u({ surfaces14d: 3, companionMsgs14d: 0 })), 'C');
+});
+
+Deno.test('classifyTier returns C for >=5 companion messages', () => {
+  assertEquals(classifyTier(u({ surfaces14d: 2, companionMsgs14d: 5 })), 'C');
+});
+
+Deno.test('classifyTier returns B for >=2 surfaces but below C', () => {
+  assertEquals(classifyTier(u({ surfaces14d: 2, companionMsgs14d: 0 })), 'B');
+});
+
+Deno.test('classifyTier returns null for <2 surfaces', () => {
+  assertEquals(classifyTier(u({ surfaces14d: 1, companionMsgs14d: 0 })), null);
+});
+
+Deno.test('pickCandidates prefers C-tier, fills with B-tier', () => {
+  const users: ActiveUser[] = [
+    u({ personId: 'b1', email: 'b1@e.com', surfaces14d: 2 }),
+    u({ personId: 'b2', email: 'b2@e.com', surfaces14d: 2 }),
+    u({ personId: 'c1', email: 'c1@e.com', surfaces14d: 4 }),
+    u({ personId: 'b3', email: 'b3@e.com', surfaces14d: 2 }),
+    u({ personId: 'c2', email: 'c2@e.com', surfaces14d: 3 }),
+  ];
+  const rng = makeDeterministicRng(42);
+  const picks = pickCandidates(users, { max: 3, excludeUserIds: new Set(), rng });
+  const tiers = picks.map(p => p.tier).sort();
+  // Both C-tier users must be picked; third slot is a B-tier
+  assertEquals(tiers.filter(t => t === 'C').length, 2);
+  assertEquals(tiers.filter(t => t === 'B').length, 1);
+});
+
+Deno.test('pickCandidates respects excludeUserIds (cooldown set)', () => {
+  const users: ActiveUser[] = [
+    u({ personId: 'c1', email: 'c1@e.com', surfaces14d: 4 }),
+    u({ personId: 'c2', email: 'c2@e.com', surfaces14d: 4 }),
+  ];
+  const rng = makeDeterministicRng(1);
+  const picks = pickCandidates(users, {
+    max: 3,
+    excludeUserIds: new Set(['c1']),
+    rng,
+  });
+  assertEquals(picks.length, 1);
+  assertEquals(picks[0].user.personId, 'c2');
+});
+
+Deno.test('pickCandidates returns empty array when nothing eligible', () => {
+  const rng = makeDeterministicRng(1);
+  const picks = pickCandidates([], { max: 3, excludeUserIds: new Set(), rng });
+  assertEquals(picks.length, 0);
+});
+
+Deno.test('pickCandidates returns fewer than max when supply is low', () => {
+  const users: ActiveUser[] = [
+    u({ personId: 'b1', email: 'b1@e.com', surfaces14d: 2 }),
+  ];
+  const rng = makeDeterministicRng(1);
+  const picks = pickCandidates(users, { max: 3, excludeUserIds: new Set(), rng });
+  assertEquals(picks.length, 1);
+  assertEquals(picks[0].tier, 'B');
+});
+
+// Helper: deterministic Mulberry32 PRNG for reproducible tests
+function makeDeterministicRng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6D2B79F5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/unify-front-end/supabase/functions/_shared/interview/selection.ts
+++ b/unify-front-end/supabase/functions/_shared/interview/selection.ts
@@ -1,0 +1,56 @@
+// supabase/functions/_shared/interview/selection.ts
+import type { ActiveUser } from './posthog.ts';
+
+export type Tier = 'C' | 'B';
+
+export interface Candidate {
+  user: ActiveUser;
+  tier: Tier;
+}
+
+export interface PickOptions {
+  max: number;
+  excludeUserIds: Set<string>;  // PostHog personId == auth.users.id
+  rng?: () => number;           // injectable for tests
+}
+
+export function classifyTier(u: ActiveUser): Tier | null {
+  if (u.surfaces14d >= 3 || u.companionMsgs14d >= 5) return 'C';
+  if (u.surfaces14d >= 2) return 'B';
+  return null;
+}
+
+function shuffle<T>(arr: T[], rng: () => number): T[] {
+  const out = arr.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+export function pickCandidates(
+  users: ActiveUser[],
+  opts: PickOptions,
+): Candidate[] {
+  const rng = opts.rng ?? Math.random;
+  const cTier: Candidate[] = [];
+  const bTier: Candidate[] = [];
+
+  for (const u of users) {
+    if (opts.excludeUserIds.has(u.personId)) continue;
+    const tier = classifyTier(u);
+    if (tier === 'C') cTier.push({ user: u, tier });
+    else if (tier === 'B') bTier.push({ user: u, tier });
+  }
+
+  const cShuffled = shuffle(cTier, rng);
+  const picks: Candidate[] = cShuffled.slice(0, opts.max);
+
+  if (picks.length < opts.max) {
+    const bShuffled = shuffle(bTier, rng);
+    picks.push(...bShuffled.slice(0, opts.max - picks.length));
+  }
+
+  return picks;
+}

--- a/unify-front-end/supabase/functions/_shared/interview/tokens.test.ts
+++ b/unify-front-end/supabase/functions/_shared/interview/tokens.test.ts
@@ -1,0 +1,53 @@
+// supabase/functions/_shared/interview/tokens.test.ts
+import { assertEquals, assertRejects } from 'https://deno.land/std@0.224.0/assert/mod.ts';
+import { signToken, verifyToken, type TokenAction } from './tokens.ts';
+
+const SECRET = 'test-secret-do-not-use-in-prod';
+
+Deno.test('signToken produces a deterministic, url-safe string', async () => {
+  const t1 = await signToken('abc-123', 'approve', SECRET);
+  const t2 = await signToken('abc-123', 'approve', SECRET);
+  assertEquals(t1, t2);
+  // url-safe base64: no +, /, =, or whitespace
+  assertEquals(/^[A-Za-z0-9_-]+$/.test(t1), true);
+});
+
+Deno.test('signToken differs by action', async () => {
+  const a = await signToken('abc-123', 'approve', SECRET);
+  const s = await signToken('abc-123', 'skip', SECRET);
+  assertEquals(a === s, false);
+});
+
+Deno.test('verifyToken returns true for matching token', async () => {
+  const t = await signToken('abc-123', 'approve', SECRET);
+  const ok = await verifyToken('abc-123', 'approve', t, SECRET);
+  assertEquals(ok, true);
+});
+
+Deno.test('verifyToken returns false for tampered id', async () => {
+  const t = await signToken('abc-123', 'approve', SECRET);
+  const ok = await verifyToken('abc-124', 'approve', t, SECRET);
+  assertEquals(ok, false);
+});
+
+Deno.test('verifyToken returns false for tampered action', async () => {
+  const t = await signToken('abc-123', 'approve', SECRET);
+  const ok = await verifyToken('abc-123', 'skip', t, SECRET);
+  assertEquals(ok, false);
+});
+
+Deno.test('verifyToken returns false for wrong secret', async () => {
+  const t = await signToken('abc-123', 'approve', SECRET);
+  const ok = await verifyToken('abc-123', 'approve', t, 'different-secret');
+  assertEquals(ok, false);
+});
+
+Deno.test('verifyToken returns false for garbage input', async () => {
+  const ok = await verifyToken('abc-123', 'approve', 'not-a-real-token', SECRET);
+  assertEquals(ok, false);
+});
+
+Deno.test('TokenAction type accepts the three valid actions', () => {
+  const actions: TokenAction[] = ['approve', 'skip', 'unsubscribe'];
+  assertEquals(actions.length, 3);
+});

--- a/unify-front-end/supabase/functions/_shared/interview/tokens.ts
+++ b/unify-front-end/supabase/functions/_shared/interview/tokens.ts
@@ -1,0 +1,49 @@
+// supabase/functions/_shared/interview/tokens.ts
+export type TokenAction = 'approve' | 'skip' | 'unsubscribe';
+
+const encoder = new TextEncoder();
+
+async function hmacSha256(secret: string, message: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(message));
+  return new Uint8Array(sig);
+}
+
+function toUrlSafeBase64(bytes: Uint8Array): string {
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+export async function signToken(
+  id: string,
+  action: TokenAction,
+  secret: string,
+): Promise<string> {
+  const sig = await hmacSha256(secret, `${id}:${action}`);
+  return toUrlSafeBase64(sig);
+}
+
+export async function verifyToken(
+  id: string,
+  action: TokenAction,
+  token: string,
+  secret: string,
+): Promise<boolean> {
+  if (!token || !/^[A-Za-z0-9_-]+$/.test(token)) return false;
+  const expected = await signToken(id, action, secret);
+  return timingSafeEqual(expected, token);
+}

--- a/unify-front-end/supabase/functions/approve-interview-invite/index.ts
+++ b/unify-front-end/supabase/functions/approve-interview-invite/index.ts
@@ -1,0 +1,103 @@
+// supabase/functions/approve-interview-invite/index.ts
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { Resend } from 'https://esm.sh/resend';
+import { verifyToken, signToken } from '../_shared/interview/tokens.ts';
+import { renderOutboundEmail, renderInfoPage } from '../_shared/interview/email-templates.ts';
+
+const SUPABASE_URL                = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY   = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const INTERVIEW_SIGNING_SECRET    = Deno.env.get('INTERVIEW_SIGNING_SECRET')!;
+const RESEND_USER_EMAILS_API_KEY  = Deno.env.get('RESEND_USER_EMAILS_API_KEY')!;
+const RESEND_INTERVIEW_FROM       = Deno.env.get('RESEND_INTERVIEW_FROM') ?? 'Savar from Unify <contact@unifysocial.ca>';
+const CAL_COM_LINK                = Deno.env.get('CAL_COM_LINK')!;
+const BUSINESS_ADDRESS            = Deno.env.get('BUSINESS_ADDRESS')!;
+const FUNCTIONS_BASE_URL          = `${SUPABASE_URL}/functions/v1`;
+const DRY_RUN                     = Deno.env.get('INTERVIEW_DRY_RUN') === 'true';
+
+const TOKEN_TTL_DAYS = 14;
+
+Deno.serve(async (req) => {
+  const url = new URL(req.url);
+  const inviteId = url.searchParams.get('i') ?? '';
+  const token    = url.searchParams.get('t') ?? '';
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const resend = new Resend(RESEND_USER_EMAILS_API_KEY);
+
+  const ok = await verifyToken(inviteId, 'approve', token, INTERVIEW_SIGNING_SECRET);
+  if (!ok) return html(renderInfoPage('Invalid or tampered approval link.'), 403);
+
+  const { data: invite } = await supabase
+    .from('interview_invites')
+    .select('*')
+    .eq('id', inviteId)
+    .maybeSingle();
+
+  if (!invite) return html(renderInfoPage('Invite not found.'), 404);
+
+  // Idempotency
+  if (invite.status === 'sent' || invite.status === 'booked') {
+    return html(renderInfoPage(`Already sent on ${new Date(invite.sent_at).toLocaleString()}.`));
+  }
+  if (invite.status === 'skipped') {
+    return html(renderInfoPage('This invite was skipped.'));
+  }
+  if (invite.status === 'expired') {
+    return html(renderInfoPage('This approval link has expired. The invite was auto-expired.'));
+  }
+  if (invite.status !== 'pending_approval' && invite.status !== 'approved') {
+    return html(renderInfoPage(`Cannot approve from status "${invite.status}".`));
+  }
+
+  // Token age check (defense-in-depth)
+  const ageDays = (Date.now() - new Date(invite.picked_at).getTime()) / 86400_000;
+  if (ageDays > TOKEN_TTL_DAYS) {
+    return html(renderInfoPage('This approval link has expired.'));
+  }
+
+  // Flip to approved
+  await supabase
+    .from('interview_invites')
+    .update({ status: 'approved', approved_at: new Date().toISOString() })
+    .eq('id', inviteId);
+
+  // Re-render outbound (so unsub URL is regenerated freshly)
+  const unsubToken = await signToken(invite.user_id, 'unsubscribe', INTERVIEW_SIGNING_SECRET);
+  const unsubUrl = `${FUNCTIONS_BASE_URL}/unsubscribe-interview?u=${invite.user_id}&t=${unsubToken}`;
+  const outbound = renderOutboundEmail({
+    recipientName:   invite.name,
+    calComLink:      CAL_COM_LINK,
+    unsubscribeUrl:  unsubUrl,
+    businessAddress: BUSINESS_ADDRESS,
+  });
+
+  if (DRY_RUN) {
+    console.log('[interview-approve] DRY_RUN — would send to', invite.email);
+    return html(renderInfoPage(`DRY RUN: would have sent to ${invite.email}.`));
+  }
+
+  const sendRes = await resend.emails.send({
+    from:    RESEND_INTERVIEW_FROM,
+    to:      invite.email,
+    subject: outbound.subject,
+    html:    outbound.html,
+    text:    outbound.text,
+    replyTo: 'contact@unifysocial.ca',
+  });
+
+  await supabase
+    .from('interview_invites')
+    .update({
+      status:          'sent',
+      sent_at:         new Date().toISOString(),
+      resend_email_id: sendRes.data?.id ?? null,
+    })
+    .eq('id', inviteId);
+
+  return html(renderInfoPage(`Sent to ${invite.email}.`));
+});
+
+function html(body: string, status = 200): Response {
+  return new Response(body, { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}

--- a/unify-front-end/supabase/functions/approve-interview-invite/index.ts
+++ b/unify-front-end/supabase/functions/approve-interview-invite/index.ts
@@ -56,12 +56,6 @@ Deno.serve(async (req) => {
     return html(renderInfoPage('This approval link has expired.'));
   }
 
-  // Flip to approved
-  await supabase
-    .from('interview_invites')
-    .update({ status: 'approved', approved_at: new Date().toISOString() })
-    .eq('id', inviteId);
-
   // Re-render outbound (so unsub URL is regenerated freshly)
   const unsubToken = await signToken(invite.user_id, 'unsubscribe', INTERVIEW_SIGNING_SECRET);
   const unsubUrl = `${FUNCTIONS_BASE_URL}/unsubscribe-interview?u=${invite.user_id}&t=${unsubToken}`;
@@ -76,6 +70,12 @@ Deno.serve(async (req) => {
     console.log('[interview-approve] DRY_RUN — would send to', invite.email);
     return html(renderInfoPage(`DRY RUN: would have sent to ${invite.email}.`));
   }
+
+  // Flip to approved (only on real send path)
+  await supabase
+    .from('interview_invites')
+    .update({ status: 'approved', approved_at: new Date().toISOString() })
+    .eq('id', inviteId);
 
   const sendRes = await resend.emails.send({
     from:    RESEND_INTERVIEW_FROM,

--- a/unify-front-end/supabase/functions/cal-booking-webhook/index.ts
+++ b/unify-front-end/supabase/functions/cal-booking-webhook/index.ts
@@ -1,0 +1,82 @@
+// supabase/functions/cal-booking-webhook/index.ts
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const SUPABASE_URL              = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const CAL_COM_WEBHOOK_SECRET    = Deno.env.get('CAL_COM_WEBHOOK_SECRET')!;
+
+const encoder = new TextEncoder();
+
+Deno.serve(async (req) => {
+  const raw = await req.text();
+  const sigHex = req.headers.get('x-cal-signature-256') ?? '';
+
+  // Verify HMAC-SHA256 of raw body against secret
+  const key = await crypto.subtle.importKey(
+    'raw', encoder.encode(CAL_COM_WEBHOOK_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+  );
+  const expected = new Uint8Array(await crypto.subtle.sign('HMAC', key, encoder.encode(raw)));
+  const expectedHex = Array.from(expected).map(b => b.toString(16).padStart(2, '0')).join('');
+  if (!timingSafeEqualHex(expectedHex, sigHex)) {
+    console.warn('[cal-webhook] signature mismatch');
+    return new Response('bad signature', { status: 403 });
+  }
+
+  let payload: any;
+  try { payload = JSON.parse(raw); } catch { return new Response('bad json', { status: 400 }); }
+
+  if (payload?.triggerEvent !== 'BOOKING_CREATED') {
+    return new Response('ignored', { status: 200 });
+  }
+
+  // Cal.com puts attendee email under payload.payload.attendees[0].email (v2 schema)
+  const email: string | undefined =
+    payload?.payload?.attendees?.[0]?.email
+    ?? payload?.payload?.responses?.email?.value
+    ?? payload?.payload?.email;
+  const bookingId: string | undefined =
+    payload?.payload?.uid
+    ?? payload?.payload?.id
+    ?? String(payload?.payload?.bookingId ?? '');
+
+  if (!email) {
+    console.log('[cal-webhook] no attendee email; ignoring');
+    return new Response('ok', { status: 200 });
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: latest } = await supabase
+    .from('interview_invites')
+    .select('id')
+    .eq('email', email)
+    .eq('status', 'sent')
+    .order('sent_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (!latest?.id) {
+    console.log('[cal-webhook] no matching sent invite for', email);
+    return new Response('ok', { status: 200 });
+  }
+
+  await supabase
+    .from('interview_invites')
+    .update({
+      status:         'booked',
+      booked_at:      new Date().toISOString(),
+      cal_booking_id: bookingId ?? null,
+    })
+    .eq('id', latest.id);
+
+  return new Response('ok', { status: 200 });
+});
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}

--- a/unify-front-end/supabase/functions/pick-interview-candidates/index.ts
+++ b/unify-front-end/supabase/functions/pick-interview-candidates/index.ts
@@ -64,16 +64,26 @@ Deno.serve(async (_req) => {
       apiKey:      POSTHOG_API_KEY,
     });
 
-    // 4. Resolve PostHog person ids to auth.users + drop do_not_contact
-    const personIds = allActive.map(u => u.personId);
+    // 4. Resolve to Supabase user via email (PostHog person_id is PostHog-internal,
+    //    NOT auth.users.id — the only stable cross-system key is email).
+    //    Re-key each ActiveUser.personId to the resolved auth.users.id so all
+    //    downstream code (inserts, cooldown, tokens) speaks Supabase ids.
+    const emails = allActive.map(u => u.email);
     const { data: validUsers } = await supabase
       .from('users')
-      .select('id, do_not_contact')
-      .in('id', personIds);
-    const allowedIds = new Set(
-      (validUsers ?? []).filter(u => !u.do_not_contact).map(u => u.id),
-    );
-    const eligible = allActive.filter(u => allowedIds.has(u.personId));
+      .select('id, email, do_not_contact, created_at')
+      .in('email', emails);
+    const emailMeta = new Map<string, { id: string; createdAt: string }>();
+    for (const u of validUsers ?? []) {
+      if (u.do_not_contact || !u.email) continue;
+      emailMeta.set(u.email as string, {
+        id: u.id as string,
+        createdAt: u.created_at as string,
+      });
+    }
+    const eligible = allActive
+      .filter(u => emailMeta.has(u.email))
+      .map(u => ({ ...u, personId: emailMeta.get(u.email)!.id }));
 
     // 5. Cooldown exclusion set
     const { data: cooldownRows } = await supabase
@@ -141,12 +151,8 @@ Deno.serve(async (_req) => {
       const approveToken = await signToken(inserted.id, 'approve', INTERVIEW_SIGNING_SECRET);
       const skipToken    = await signToken(inserted.id, 'skip',    INTERVIEW_SIGNING_SECRET);
 
-      // user_created_at for display: from auth.users via users join (fallback to row created)
-      const { data: userMeta } = await supabase
-        .from('users')
-        .select('created_at')
-        .eq('id', pick.user.personId)
-        .maybeSingle();
+      // user_created_at for display: from cached emailMeta (avoid N+1 query)
+      const createdAt = emailMeta.get(pick.user.email)?.createdAt ?? inserted.created_at;
 
       approvalCandidates.push({
         email:              pick.user.email,
@@ -155,7 +161,7 @@ Deno.serve(async (_req) => {
         surfaces14d:        pick.user.surfaces14d,
         events14d:          pick.user.events14d,
         companionMsgs14d:   pick.user.companionMsgs14d,
-        userCreatedAt:      formatDate(userMeta?.created_at ?? inserted.created_at),
+        userCreatedAt:      formatDate(createdAt),
         emailSubject:       outbound.subject,
         emailBodyExcerpt:   outbound.text.slice(0, 240) + (outbound.text.length > 240 ? '…' : ''),
         approveUrl:         `${FUNCTIONS_BASE_URL}/approve-interview-invite?i=${inserted.id}&t=${approveToken}`,

--- a/unify-front-end/supabase/functions/pick-interview-candidates/index.ts
+++ b/unify-front-end/supabase/functions/pick-interview-candidates/index.ts
@@ -176,18 +176,18 @@ Deno.serve(async (_req) => {
       warning,
     });
 
-    if (DRY_RUN) {
-      console.log('[interview-picker] DRY_RUN — would email', APPROVAL_EMAIL_RECIPIENT, 'subject:', approval.subject);
-    } else {
-      await resend.emails.send({
-        from:     RESEND_INTERVIEW_FROM,
-        to:       APPROVAL_EMAIL_RECIPIENT,
-        subject:  approval.subject,
-        html:     approval.html,
-        text:     approval.text,
-        replyTo:  'contact@unifysocial.ca',
-      });
-    }
+    // The approval email always sends — even in DRY_RUN — because it's the
+    // only way the operator sees what the picker would have done. Only the
+    // per-candidate outbound emails are suppressed by DRY_RUN (handled in the
+    // approve handler).
+    await resend.emails.send({
+      from:     RESEND_INTERVIEW_FROM,
+      to:       APPROVAL_EMAIL_RECIPIENT,
+      subject:  approval.subject,
+      html:     approval.html,
+      text:     approval.text,
+      replyTo:  'contact@unifysocial.ca',
+    });
 
     return new Response(JSON.stringify({
       ok: true,

--- a/unify-front-end/supabase/functions/pick-interview-candidates/index.ts
+++ b/unify-front-end/supabase/functions/pick-interview-candidates/index.ts
@@ -1,0 +1,219 @@
+// supabase/functions/pick-interview-candidates/index.ts
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { Resend } from 'https://esm.sh/resend';
+import { fetchActiveUsers14d } from '../_shared/interview/posthog.ts';
+import { pickCandidates } from '../_shared/interview/selection.ts';
+import { signToken } from '../_shared/interview/tokens.ts';
+import {
+  renderOutboundEmail,
+  renderApprovalEmail,
+  type ApprovalCandidate,
+} from '../_shared/interview/email-templates.ts';
+
+const SUPABASE_URL                = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY   = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const POSTHOG_HOST                = Deno.env.get('POSTHOG_HOST') ?? 'https://us.i.posthog.com';
+const POSTHOG_PROJECT_ID          = Deno.env.get('POSTHOG_PROJECT_ID')!;
+const POSTHOG_API_KEY             = Deno.env.get('POSTHOG_API_KEY')!;
+const INTERVIEW_SIGNING_SECRET    = Deno.env.get('INTERVIEW_SIGNING_SECRET')!;
+const RESEND_USER_EMAILS_API_KEY  = Deno.env.get('RESEND_USER_EMAILS_API_KEY')!;
+const RESEND_INTERVIEW_FROM       = Deno.env.get('RESEND_INTERVIEW_FROM') ?? 'Savar from Unify <contact@unifysocial.ca>';
+const APPROVAL_EMAIL_RECIPIENT    = Deno.env.get('APPROVAL_EMAIL_RECIPIENT')!;
+const SAVAR_USER_ID               = Deno.env.get('SAVAR_USER_ID')!;
+const CAL_COM_LINK                = Deno.env.get('CAL_COM_LINK')!;
+const BUSINESS_ADDRESS            = Deno.env.get('BUSINESS_ADDRESS')!;
+const FUNCTIONS_BASE_URL          = `${SUPABASE_URL}/functions/v1`;
+const DRY_RUN                     = Deno.env.get('INTERVIEW_DRY_RUN') === 'true';
+
+const COOLDOWN_DAYS = 12 * 7;       // 12 weeks
+const EXPIRE_AFTER_DAYS = 6;        // pending_approval older than 6 days → expired
+const MAX_PICKS = 3;
+
+Deno.serve(async (_req) => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const resend = new Resend(RESEND_USER_EMAILS_API_KEY);
+
+  try {
+    // 1. Expire stale pending_approval rows
+    await supabase
+      .from('interview_invites')
+      .update({ status: 'expired' })
+      .eq('status', 'pending_approval')
+      .lt('picked_at', new Date(Date.now() - EXPIRE_AFTER_DAYS * 86400_000).toISOString());
+
+    // 2. Missed-run detection (compute warning before picking)
+    const { data: lastRows } = await supabase
+      .from('interview_invites')
+      .select('picked_at')
+      .order('picked_at', { ascending: false })
+      .limit(1);
+    let warning: string | null = null;
+    if (lastRows?.[0]?.picked_at) {
+      const last = new Date(lastRows[0].picked_at).getTime();
+      const daysSince = (Date.now() - last) / 86400_000;
+      if (daysSince > 8) {
+        warning = `Last successful pick was ${Math.floor(daysSince)} days ago — previous run may have failed silently`;
+      }
+    }
+
+    // 3. Fetch eligible users from PostHog
+    const allActive = await fetchActiveUsers14d({
+      posthogHost: POSTHOG_HOST,
+      projectId:   POSTHOG_PROJECT_ID,
+      apiKey:      POSTHOG_API_KEY,
+    });
+
+    // 4. Resolve PostHog person ids to auth.users + drop do_not_contact
+    const personIds = allActive.map(u => u.personId);
+    const { data: validUsers } = await supabase
+      .from('users')
+      .select('id, do_not_contact')
+      .in('id', personIds);
+    const allowedIds = new Set(
+      (validUsers ?? []).filter(u => !u.do_not_contact).map(u => u.id),
+    );
+    const eligible = allActive.filter(u => allowedIds.has(u.personId));
+
+    // 5. Cooldown exclusion set
+    const { data: cooldownRows } = await supabase
+      .from('interview_invites')
+      .select('user_id')
+      .in('status', ['approved', 'sent', 'booked'])
+      .gte('picked_at', new Date(Date.now() - COOLDOWN_DAYS * 86400_000).toISOString());
+    const excludeUserIds = new Set<string>(
+      (cooldownRows ?? []).map(r => r.user_id as string),
+    );
+    excludeUserIds.add(SAVAR_USER_ID);
+
+    // 6. Tier + pick
+    const picks = pickCandidates(eligible, { max: MAX_PICKS, excludeUserIds });
+
+    // 7. Pipeline health (for the approval email footer)
+    const cTierCount = eligible.filter(u =>
+      u.surfaces14d >= 3 || u.companionMsgs14d >= 5
+    ).length;
+    const bTierCount = eligible.filter(u =>
+      !(u.surfaces14d >= 3 || u.companionMsgs14d >= 5) && u.surfaces14d >= 2
+    ).length;
+
+    // 8. For each pick: insert row, render outbound preview, build signed URLs
+    const approvalCandidates: ApprovalCandidate[] = [];
+    for (const pick of picks) {
+      const { data: inserted, error: insertErr } = await supabase
+        .from('interview_invites')
+        .insert({
+          user_id:            pick.user.personId,
+          email:              pick.user.email,
+          name:               pick.user.name,
+          tier:               pick.tier,
+          surfaces_14d:       pick.user.surfaces14d,
+          events_14d:         pick.user.events14d,
+          companion_msgs_14d: pick.user.companionMsgs14d,
+          status:             'pending_approval',
+        })
+        .select('id, created_at')
+        .single();
+      if (insertErr || !inserted) {
+        console.error('[interview-picker] insert failed:', insertErr);
+        continue;
+      }
+
+      // Render outbound preview now so it shows in approval email and can be
+      // sent verbatim from the approve handler. Persist subject/body on row.
+      const unsubToken = await signToken(pick.user.personId, 'unsubscribe', INTERVIEW_SIGNING_SECRET);
+      const unsubUrl = `${FUNCTIONS_BASE_URL}/unsubscribe-interview?u=${pick.user.personId}&t=${unsubToken}`;
+      const outbound = renderOutboundEmail({
+        recipientName:   pick.user.name,
+        calComLink:      CAL_COM_LINK,
+        unsubscribeUrl:  unsubUrl,
+        businessAddress: BUSINESS_ADDRESS,
+      });
+
+      await supabase
+        .from('interview_invites')
+        .update({
+          email_subject: outbound.subject,
+          email_body:    outbound.text,  // store plain text; HTML re-rendered at send time
+        })
+        .eq('id', inserted.id);
+
+      const approveToken = await signToken(inserted.id, 'approve', INTERVIEW_SIGNING_SECRET);
+      const skipToken    = await signToken(inserted.id, 'skip',    INTERVIEW_SIGNING_SECRET);
+
+      // user_created_at for display: from auth.users via users join (fallback to row created)
+      const { data: userMeta } = await supabase
+        .from('users')
+        .select('created_at')
+        .eq('id', pick.user.personId)
+        .maybeSingle();
+
+      approvalCandidates.push({
+        email:              pick.user.email,
+        name:               pick.user.name,
+        tier:               pick.tier,
+        surfaces14d:        pick.user.surfaces14d,
+        events14d:          pick.user.events14d,
+        companionMsgs14d:   pick.user.companionMsgs14d,
+        userCreatedAt:      formatDate(userMeta?.created_at ?? inserted.created_at),
+        emailSubject:       outbound.subject,
+        emailBodyExcerpt:   outbound.text.slice(0, 240) + (outbound.text.length > 240 ? '…' : ''),
+        approveUrl:         `${FUNCTIONS_BASE_URL}/approve-interview-invite?i=${inserted.id}&t=${approveToken}`,
+        skipUrl:            `${FUNCTIONS_BASE_URL}/skip-interview-invite?i=${inserted.id}&t=${skipToken}`,
+      });
+    }
+
+    // 9. Send the approval email
+    const approval = renderApprovalEmail({
+      candidates: approvalCandidates,
+      pipelineHealth: { cTier: cTierCount, bTier: bTierCount, inCooldown: excludeUserIds.size - 1 /* minus Savar */ },
+      warning,
+    });
+
+    if (DRY_RUN) {
+      console.log('[interview-picker] DRY_RUN — would email', APPROVAL_EMAIL_RECIPIENT, 'subject:', approval.subject);
+    } else {
+      await resend.emails.send({
+        from:     RESEND_INTERVIEW_FROM,
+        to:       APPROVAL_EMAIL_RECIPIENT,
+        subject:  approval.subject,
+        html:     approval.html,
+        text:     approval.text,
+        replyTo:  'contact@unifysocial.ca',
+      });
+    }
+
+    return new Response(JSON.stringify({
+      ok: true,
+      picked: approvalCandidates.length,
+      eligible: eligible.length,
+      cTier: cTierCount,
+      bTier: bTierCount,
+      cooldown: excludeUserIds.size - 1,
+      warning,
+      dryRun: DRY_RUN,
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+  } catch (err) {
+    console.error('[interview-picker] error:', err);
+    // Send Savar a one-sentence failure notice
+    try {
+      await resend.emails.send({
+        from:    RESEND_INTERVIEW_FROM,
+        to:      APPROVAL_EMAIL_RECIPIENT,
+        subject: '[Unify Picker] Failure — check logs',
+        text:    `The interview picker errored: ${String(err).slice(0, 240)}\n\nSupabase logs: ${SUPABASE_URL.replace('.supabase.co', '.supabase.com')}/project/_/functions`,
+      });
+    } catch (sendErr) {
+      console.error('[interview-picker] failure-notice send also failed:', sendErr);
+    }
+    return new Response(JSON.stringify({ ok: false, error: String(err) }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+});
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-CA', { year: 'numeric', month: 'short', day: 'numeric' });
+}

--- a/unify-front-end/supabase/functions/resend-bounce-webhook/index.ts
+++ b/unify-front-end/supabase/functions/resend-bounce-webhook/index.ts
@@ -1,0 +1,68 @@
+// supabase/functions/resend-bounce-webhook/index.ts
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { Webhook } from 'https://esm.sh/svix';
+
+const SUPABASE_URL              = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const RESEND_WEBHOOK_SECRET     = Deno.env.get('RESEND_WEBHOOK_SECRET')!;
+
+// Resend uses Svix for webhook signing — verify with their helper.
+Deno.serve(async (req) => {
+  const raw = await req.text();
+  const headers: Record<string, string> = {};
+  req.headers.forEach((v, k) => { headers[k] = v; });
+
+  let payload: any;
+  try {
+    const wh = new Webhook(RESEND_WEBHOOK_SECRET);
+    payload = wh.verify(raw, headers);
+  } catch (err) {
+    console.warn('[resend-bounce] verify failed:', err);
+    return new Response('bad signature', { status: 403 });
+  }
+
+  if (payload?.type !== 'email.bounced') {
+    return new Response('ignored', { status: 200 });
+  }
+  // Only hard bounces suppress
+  const bounceType: string = payload?.data?.bounce?.type ?? payload?.data?.bounce_type ?? '';
+  if (bounceType.toLowerCase() !== 'hard' && bounceType !== 'Permanent') {
+    return new Response('soft bounce; ignored', { status: 200 });
+  }
+
+  const resendEmailId: string | undefined = payload?.data?.email_id ?? payload?.data?.id;
+  if (!resendEmailId) {
+    console.log('[resend-bounce] no email_id; ignoring');
+    return new Response('ok', { status: 200 });
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: invite } = await supabase
+    .from('interview_invites')
+    .select('id, user_id')
+    .eq('resend_email_id', resendEmailId)
+    .maybeSingle();
+
+  if (!invite) {
+    console.log('[resend-bounce] no matching invite for', resendEmailId);
+    return new Response('ok', { status: 200 });
+  }
+
+  await supabase
+    .from('interview_invites')
+    .update({ status: 'bounced' })
+    .eq('id', invite.id);
+
+  await supabase
+    .from('users')
+    .update({
+      do_not_contact: true,
+      do_not_contact_at: new Date().toISOString(),
+      do_not_contact_reason: 'hard_bounce',
+    })
+    .eq('id', invite.user_id);
+
+  return new Response('ok', { status: 200 });
+});

--- a/unify-front-end/supabase/functions/skip-interview-invite/index.ts
+++ b/unify-front-end/supabase/functions/skip-interview-invite/index.ts
@@ -1,0 +1,52 @@
+// supabase/functions/skip-interview-invite/index.ts
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { verifyToken } from '../_shared/interview/tokens.ts';
+import { renderInfoPage } from '../_shared/interview/email-templates.ts';
+
+const SUPABASE_URL              = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const INTERVIEW_SIGNING_SECRET  = Deno.env.get('INTERVIEW_SIGNING_SECRET')!;
+
+Deno.serve(async (req) => {
+  const url = new URL(req.url);
+  const inviteId = url.searchParams.get('i') ?? '';
+  const token    = url.searchParams.get('t') ?? '';
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const ok = await verifyToken(inviteId, 'skip', token, INTERVIEW_SIGNING_SECRET);
+  if (!ok) return html(renderInfoPage('Invalid or tampered link.'), 403);
+
+  const { data: invite } = await supabase
+    .from('interview_invites')
+    .select('id, status, email')
+    .eq('id', inviteId)
+    .maybeSingle();
+
+  if (!invite) return html(renderInfoPage('Invite not found.'), 404);
+
+  if (invite.status === 'skipped') {
+    return html(renderInfoPage(`Already skipped.`));
+  }
+  if (invite.status === 'sent' || invite.status === 'booked') {
+    return html(renderInfoPage("This invite was already sent and can't be skipped."), 409);
+  }
+  if (invite.status === 'expired') {
+    return html(renderInfoPage('This invite was already auto-expired.'));
+  }
+  if (invite.status !== 'pending_approval') {
+    return html(renderInfoPage(`Cannot skip from status "${invite.status}".`));
+  }
+
+  await supabase
+    .from('interview_invites')
+    .update({ status: 'skipped' })
+    .eq('id', inviteId);
+
+  return html(renderInfoPage(`Skipped: ${invite.email} will not be contacted this week.`));
+});
+
+function html(body: string, status = 200): Response {
+  return new Response(body, { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}

--- a/unify-front-end/supabase/functions/unsubscribe-interview/index.ts
+++ b/unify-front-end/supabase/functions/unsubscribe-interview/index.ts
@@ -1,0 +1,57 @@
+// supabase/functions/unsubscribe-interview/index.ts
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { verifyToken } from '../_shared/interview/tokens.ts';
+import {
+  renderUnsubscribeConfirmation,
+  renderInfoPage,
+} from '../_shared/interview/email-templates.ts';
+
+const SUPABASE_URL              = Deno.env.get('SUPABASE_URL')!;
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+const INTERVIEW_SIGNING_SECRET  = Deno.env.get('INTERVIEW_SIGNING_SECRET')!;
+
+Deno.serve(async (req) => {
+  const url = new URL(req.url);
+  const userId = url.searchParams.get('u') ?? '';
+  const token  = url.searchParams.get('t') ?? '';
+
+  const ok = await verifyToken(userId, 'unsubscribe', token, INTERVIEW_SIGNING_SECRET);
+  if (!ok) {
+    return html(renderInfoPage('Invalid or tampered unsubscribe link.'), 403);
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  // Flip flag (idempotent — UPDATE on already-true row is fine)
+  await supabase
+    .from('users')
+    .update({
+      do_not_contact: true,
+      do_not_contact_at: new Date().toISOString(),
+      do_not_contact_reason: 'unsubscribed',
+    })
+    .eq('id', userId);
+
+  // Mark most recent invite for this user (if any) as unsubscribed for history
+  const { data: latest } = await supabase
+    .from('interview_invites')
+    .select('id')
+    .eq('user_id', userId)
+    .order('picked_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (latest?.id) {
+    await supabase
+      .from('interview_invites')
+      .update({ status: 'unsubscribed' })
+      .eq('id', latest.id)
+      .in('status', ['sent', 'approved', 'pending_approval']);
+  }
+
+  return html(renderUnsubscribeConfirmation());
+});
+
+function html(body: string, status = 200): Response {
+  return new Response(body, { status, headers: { 'Content-Type': 'text/html; charset=utf-8' } });
+}

--- a/unify-front-end/supabase/migrations/20260518000000_interview_picker_schema.sql
+++ b/unify-front-end/supabase/migrations/20260518000000_interview_picker_schema.sql
@@ -1,0 +1,69 @@
+-- Add opt-out columns to public.users
+ALTER TABLE public.users
+  ADD COLUMN do_not_contact boolean NOT NULL DEFAULT false,
+  ADD COLUMN do_not_contact_at timestamptz,
+  ADD COLUMN do_not_contact_reason text
+    CHECK (do_not_contact_reason IN ('unsubscribed','hard_bounce','manual')
+           OR do_not_contact_reason IS NULL);
+
+-- Create interview_invites pipeline table
+CREATE TABLE public.interview_invites (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id             uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  email               text NOT NULL,
+  name                text,
+  tier                text NOT NULL CHECK (tier IN ('C','B')),
+  surfaces_14d        int  NOT NULL,
+  events_14d          int  NOT NULL,
+  companion_msgs_14d  int  NOT NULL,
+  picked_at           timestamptz NOT NULL DEFAULT now(),
+  status              text NOT NULL DEFAULT 'pending_approval'
+    CHECK (status IN (
+      'pending_approval','approved','sent','skipped',
+      'booked','unsubscribed','bounced','expired'
+    )),
+  email_subject       text,
+  email_body          text,
+  resend_email_id     text,
+  approved_at         timestamptz,
+  sent_at             timestamptz,
+  booked_at           timestamptz,
+  cal_booking_id      text,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+-- Cooldown lookup index
+CREATE INDEX idx_invites_user_picked
+  ON public.interview_invites(user_id, picked_at DESC);
+
+-- In-flight status lookup
+CREATE INDEX idx_invites_status
+  ON public.interview_invites(status)
+  WHERE status IN ('pending_approval','approved','sent');
+
+-- Match by email (cal.com webhook)
+CREATE INDEX idx_invites_email_sent
+  ON public.interview_invites(email, sent_at DESC)
+  WHERE status = 'sent';
+
+-- Match by resend_email_id (bounce webhook)
+CREATE INDEX idx_invites_resend_id
+  ON public.interview_invites(resend_email_id)
+  WHERE resend_email_id IS NOT NULL;
+
+-- Auto-touch updated_at
+CREATE OR REPLACE FUNCTION public.tg_interview_invites_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_interview_invites_updated_at
+BEFORE UPDATE ON public.interview_invites
+FOR EACH ROW EXECUTE FUNCTION public.tg_interview_invites_updated_at();
+
+-- Lock down to service-role only (no policies = no anon/authenticated access)
+ALTER TABLE public.interview_invites ENABLE ROW LEVEL SECURITY;

--- a/unify-front-end/supabase/migrations/20260518000000_interview_picker_schema.sql
+++ b/unify-front-end/supabase/migrations/20260518000000_interview_picker_schema.sql
@@ -1,15 +1,15 @@
 -- Add opt-out columns to public.users
 ALTER TABLE public.users
-  ADD COLUMN do_not_contact boolean NOT NULL DEFAULT false,
-  ADD COLUMN do_not_contact_at timestamptz,
-  ADD COLUMN do_not_contact_reason text
+  ADD COLUMN IF NOT EXISTS do_not_contact boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS do_not_contact_at timestamptz,
+  ADD COLUMN IF NOT EXISTS do_not_contact_reason text
     CHECK (do_not_contact_reason IN ('unsubscribed','hard_bounce','manual')
            OR do_not_contact_reason IS NULL);
 
 -- Create interview_invites pipeline table
-CREATE TABLE public.interview_invites (
+CREATE TABLE IF NOT EXISTS public.interview_invites (
   id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id             uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  user_id             uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
   email               text NOT NULL,
   name                text,
   tier                text NOT NULL CHECK (tier IN ('C','B')),
@@ -34,21 +34,21 @@ CREATE TABLE public.interview_invites (
 );
 
 -- Cooldown lookup index
-CREATE INDEX idx_invites_user_picked
+CREATE INDEX IF NOT EXISTS idx_invites_user_picked
   ON public.interview_invites(user_id, picked_at DESC);
 
 -- In-flight status lookup
-CREATE INDEX idx_invites_status
+CREATE INDEX IF NOT EXISTS idx_invites_status
   ON public.interview_invites(status)
   WHERE status IN ('pending_approval','approved','sent');
 
 -- Match by email (cal.com webhook)
-CREATE INDEX idx_invites_email_sent
+CREATE INDEX IF NOT EXISTS idx_invites_email_sent
   ON public.interview_invites(email, sent_at DESC)
   WHERE status = 'sent';
 
 -- Match by resend_email_id (bounce webhook)
-CREATE INDEX idx_invites_resend_id
+CREATE INDEX IF NOT EXISTS idx_invites_resend_id
   ON public.interview_invites(resend_email_id)
   WHERE resend_email_id IS NOT NULL;
 

--- a/unify-front-end/supabase/migrations/20260518000001_interview_picker_cron.sql
+++ b/unify-front-end/supabase/migrations/20260518000001_interview_picker_cron.sql
@@ -9,20 +9,17 @@ WHERE EXISTS (
 );
 
 -- Sunday 6pm PDT = Monday 01:00 UTC. Drifts to 5pm PST in winter (acceptable).
--- The Authorization bearer is the project ANON key, which is public (it ships
--- in the React Native app bundle). The picker function has JWT verification
--- enabled, so this validates the request format; all real authorization is
--- done internally by the function using its service-role env var.
+-- The picker function is deployed with --no-verify-jwt because the only
+-- caller is this cron (and rare manual smoke tests via curl during testing).
+-- All authorization is done internally by the function using its service-role
+-- env var. Avoiding any Authorization header keeps secrets out of source.
 SELECT cron.schedule(
   'pick-interview-candidates-weekly',
   '0 1 * * 1',
   $$
   SELECT net.http_post(
     url := 'https://wrbauxutkysljmsqojts.supabase.co/functions/v1/pick-interview-candidates',
-    headers := jsonb_build_object(
-      'Content-Type',  'application/json',
-      'Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndyYmF1eHV0a3lzbGptc3FvanRzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTIxOTY4MzMsImV4cCI6MjA2Nzc3MjgzM30.rB-q1BN2dPUcg8whhoBgkZJdt1rXTxX6JiDj16dkwdo'
-    ),
+    headers := jsonb_build_object('Content-Type', 'application/json'),
     body := '{}'::jsonb
   );
   $$

--- a/unify-front-end/supabase/migrations/20260518000001_interview_picker_cron.sql
+++ b/unify-front-end/supabase/migrations/20260518000001_interview_picker_cron.sql
@@ -2,16 +2,26 @@
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 CREATE EXTENSION IF NOT EXISTS pg_net;
 
+-- Remove any prior version of this job (safe re-apply)
+SELECT cron.unschedule('pick-interview-candidates-weekly')
+WHERE EXISTS (
+  SELECT 1 FROM cron.job WHERE jobname = 'pick-interview-candidates-weekly'
+);
+
 -- Sunday 6pm PDT = Monday 01:00 UTC. Drifts to 5pm PST in winter (acceptable).
+-- The Authorization bearer is the project ANON key, which is public (it ships
+-- in the React Native app bundle). The picker function has JWT verification
+-- enabled, so this validates the request format; all real authorization is
+-- done internally by the function using its service-role env var.
 SELECT cron.schedule(
   'pick-interview-candidates-weekly',
   '0 1 * * 1',
   $$
   SELECT net.http_post(
-    url := current_setting('app.supabase_url') || '/functions/v1/pick-interview-candidates',
+    url := 'https://wrbauxutkysljmsqojts.supabase.co/functions/v1/pick-interview-candidates',
     headers := jsonb_build_object(
       'Content-Type',  'application/json',
-      'Authorization', 'Bearer ' || current_setting('app.service_role_key')
+      'Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6IndyYmF1eHV0a3lzbGptc3FvanRzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTIxOTY4MzMsImV4cCI6MjA2Nzc3MjgzM30.rB-q1BN2dPUcg8whhoBgkZJdt1rXTxX6JiDj16dkwdo'
     ),
     body := '{}'::jsonb
   );

--- a/unify-front-end/supabase/migrations/20260518000001_interview_picker_cron.sql
+++ b/unify-front-end/supabase/migrations/20260518000001_interview_picker_cron.sql
@@ -1,0 +1,19 @@
+-- Enable extensions if not already
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+-- Sunday 6pm PDT = Monday 01:00 UTC. Drifts to 5pm PST in winter (acceptable).
+SELECT cron.schedule(
+  'pick-interview-candidates-weekly',
+  '0 1 * * 1',
+  $$
+  SELECT net.http_post(
+    url := current_setting('app.supabase_url') || '/functions/v1/pick-interview-candidates',
+    headers := jsonb_build_object(
+      'Content-Type',  'application/json',
+      'Authorization', 'Bearer ' || current_setting('app.service_role_key')
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);


### PR DESCRIPTION
## Summary

Production-deployed and live in DRY_RUN mode. Automates weekly selection of 3 power-user candidates for founder-led interviews, generates personalized outbound emails, and tracks bookings via cal.com webhook.

- 6 Supabase edge functions composed from 4 unit-tested TypeScript modules
- Single `interview_invites` table + `users.do_not_contact` column
- pg_cron fires Sunday 6pm PDT (\`0 1 * * 1\` UTC) automatically
- Stateless HMAC-signed magic links for one-click approve/skip/unsubscribe (no token storage, recompute-and-compare)
- CASL-compliant outbound email with mailing address + one-click unsubscribe
- Cal.com \`BOOKING_CREATED\` webhook flips status \`sent\` → \`booked\`
- Resend \`email.bounced\` webhook hard-bounces flip \`do_not_contact=true\`
- 28 unit tests, all passing
- Tier selection: prefer C-tier (≥3 surfaces or ≥5 companion msgs in 14d), fall back to B-tier (≥2 surfaces), pure random within tier, 12-week cooldown after \`sent\`

## Architecture

Activity source is PostHog (HogQL query). User identity resolution joins on **email** (not PostHog \`person_id\`, which is PostHog-internal and was an early bug fixed in 7ae39858). Operator approval lands in a single email to \`savar.gupta1922@gmail.com\` with per-candidate Approve/Skip magic links. DRY_RUN suppresses only candidate-bound emails — the operator approval email always sends so the human can see what the picker would do.

## Spec & plan

- Spec: \`docs/superpowers/specs/2026-05-18-weekly-interview-picker-design.md\` (local-only, gitignored)
- Plan: \`docs/superpowers/plans/2026-05-18-weekly-interview-picker.md\` (local-only, gitignored)

## Deploy state (already in production)

| Component | State |
|---|---|
| Schema migration applied | ✅ |
| Cron migration applied | ✅ |
| 6 edge functions deployed | ✅ (5 with \`--no-verify-jwt\` for external callers) |
| All 11 env vars set | ✅ |
| Cal.com webhook wired | ✅ ping returned 200 |
| Resend webhook wired | ✅ signature verification confirmed via negative test (403 on unsigned) |
| \`INTERVIEW_DRY_RUN\` | \`true\` until operator flips it |

## Known issues / follow-ups

- **\`person.properties.name\` is null** in PostHog for all users — outbound emails will say "Hi there," not a name. One-line fix in the app's \`posthog.identify()\` call. Not blocking.
- **\`bounceType !== 'Permanent'\` dead branch** in \`resend-bounce-webhook\`. Resend uses \`"hard"\`. Harmless.
- **Cal.com webhook payload variants**: \`cal-booking-webhook\` handles three possible attendee-email locations. Should match real bookings — verify on first live booking.
- **From address is \`savar@noreply.unifysocial.ca\`** (only verified Resend subdomain). Verifying root \`unifysocial.ca\` in Resend later would let us send from \`contact@unifysocial.ca\` — better for reply rates. DNS work is additive and won't affect Google Workspace.

## Test plan

- [x] Picker query returns expected eligible count vs PostHog data
- [x] Tier C → fallback B selection logic
- [x] Approval email rendered + delivered
- [x] Approve magic link → DRY_RUN no-op page (no DB mutation)
- [x] Cal.com webhook ping (200 with signature verification)
- [x] Resend webhook negative test (403 bad-sig on unsigned)
- [ ] Sunday Sun 24 May: confirm pg_cron auto-fire produces approval email
- [ ] Sun 31 May (target): flip \`INTERVIEW_DRY_RUN=false\`, approve one candidate, verify outbound delivery + cal.com booking webhook on first real booking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automated interview candidate selection and invitation system based on user activity metrics
  * Added email workflow management including bounce detection, unsubscribe handling, and status tracking
  * Integrated Cal.com booking sync to automatically track interview confirmations
  * Built secure token-based approval and skip flows for interview recipients
  * Enabled weekly automated candidate selection runs with safety features and monitoring

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UnifyCN/mobile-app/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->