### PR TITLE
fix(companion): unbreak scrolling mid-conversation

### DIFF
--- a/unify-front-end/app/(tabs)/companion/index.tsx
+++ b/unify-front-end/app/(tabs)/companion/index.tsx
@@ -501,10 +501,11 @@ export default function CompanionScreen() {
             NOT wrapped in a Pressable: wrapping a scrollable in a Pressable
             creates a gesture-responder race with the list's scroll responder
             (especially while programmatic scrolls or rapid state updates are
-            in flight), which can leave the list unscrollable. Instead, the
-            list dismisses the keyboard on drag (keyboardDismissMode) and on
-            scroll start; the tap-to-dismiss Pressable is only used for the
-            non-scrollable empty/loading states. */}
+            in flight), which can leave the list unscrollable. Keyboard
+            dismissal: keyboardDismissMode='interactive' handles smooth
+            drag-to-dismiss, keyboardShouldPersistTaps='handled' dismisses on
+            tap-outside-children. The tap-to-dismiss Pressable is only used
+            for the non-scrollable empty/loading states. */}
         {showLoadingState ? (
           <Pressable style={styles.messagesArea} onPress={Keyboard.dismiss}>
             <View style={styles.emptyContainer}>
@@ -539,7 +540,6 @@ export default function CompanionScreen() {
             ListFooterComponent={renderLoadingIndicator}
             keyboardShouldPersistTaps='handled'
             keyboardDismissMode='interactive'
-            onScrollBeginDrag={Keyboard.dismiss}
             onScroll={handleScroll}
             scrollEventThrottle={16}
             initialNumToRender={10}

--- a/unify-front-end/app/(tabs)/companion/index.tsx
+++ b/unify-front-end/app/(tabs)/companion/index.tsx
@@ -17,6 +17,8 @@ import {
   Keyboard,
   ActivityIndicator,
   Platform,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
 } from 'react-native';
 import { History, Plus } from 'lucide-react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -187,6 +189,10 @@ export default function CompanionScreen() {
   // Ref for the text input to handle focusing
   const inputRef = useRef<TextInput>(null);
   const previousMessageCountRef = useRef<number>(0);
+  // Tracks whether the user is currently pinned near the bottom of the list.
+  // While true, new content auto-scrolls into view; when the user scrolls up
+  // to read earlier messages, we stop fighting their gesture.
+  const isNearBottomRef = useRef<boolean>(true);
 
   const { data: usage } = useChatbotUsage();
   const { currentUser } = useCurrentUser();
@@ -243,23 +249,41 @@ export default function CompanionScreen() {
     }
     resetDraftState();
     previousMessageCountRef.current = 0;
+    isNearBottomRef.current = true;
   }, [conversationId, resetDraftState]);
 
-  // Scroll to end only when new messages are added (not when sources expand/collapse)
+  // Scroll to end only when new messages are added (not when sources expand/collapse).
+  // Skip while the user has scrolled up to read earlier messages, and use a
+  // non-animated scroll while a bot response is streaming so the auto-scroll
+  // doesn't fight a user gesture mid-stream.
   useEffect(() => {
     const currentMessageCount = displayMessages.length;
     const previousMessageCount = previousMessageCountRef.current;
 
-    // Only scroll if message count increased (new message added)
-    if (currentMessageCount > previousMessageCount && currentMessageCount > 0) {
-      // Use setTimeout to ensure the layout has updated
+    if (
+      currentMessageCount > previousMessageCount &&
+      currentMessageCount > 0 &&
+      isNearBottomRef.current
+    ) {
+      const animated = !streamingBotMessage;
       setTimeout(() => {
-        flatListRef.current?.scrollToEnd({ animated: true });
+        flatListRef.current?.scrollToEnd({ animated });
       }, 100);
     }
 
     previousMessageCountRef.current = currentMessageCount;
-  }, [displayMessages.length]);
+  }, [displayMessages.length, streamingBotMessage]);
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      const distanceFromBottom =
+        contentSize.height - (contentOffset.y + layoutMeasurement.height);
+      isNearBottomRef.current = distanceFromBottom < 80;
+    },
+    []
+  );
 
   const handleSendMessage = useCallback(
     async (messageText?: string) => {
@@ -420,6 +444,7 @@ export default function CompanionScreen() {
     setCurrentConversationId(null);
     resetDraftState();
     previousMessageCountRef.current = 0;
+    isNearBottomRef.current = true;
     Keyboard.dismiss();
     router.replace('/(tabs)/companion' as any);
   }, [resetDraftState, router]);
@@ -472,15 +497,22 @@ export default function CompanionScreen() {
           }
         />
 
-        {/* Messages - takes up available space. Tapping anywhere in this
-            area dismisses the keyboard; interactive children (messages,
-            suggestion chips, etc.) still receive their own taps first. */}
-        <Pressable style={styles.messagesArea} onPress={Keyboard.dismiss}>
-          {showLoadingState ? (
+        {/* Messages - takes up available space. The FlatList is intentionally
+            NOT wrapped in a Pressable: wrapping a scrollable in a Pressable
+            creates a gesture-responder race with the list's scroll responder
+            (especially while programmatic scrolls or rapid state updates are
+            in flight), which can leave the list unscrollable. Instead, the
+            list dismisses the keyboard on drag (keyboardDismissMode) and on
+            scroll start; the tap-to-dismiss Pressable is only used for the
+            non-scrollable empty/loading states. */}
+        {showLoadingState ? (
+          <Pressable style={styles.messagesArea} onPress={Keyboard.dismiss}>
             <View style={styles.emptyContainer}>
               <ActivityIndicator size='large' color={Theme.surfaceBlue} />
             </View>
-          ) : showEmptyState ? (
+          </Pressable>
+        ) : showEmptyState ? (
+          <Pressable style={styles.messagesArea} onPress={Keyboard.dismiss}>
             <View style={styles.emptyState}>
               <View style={styles.dottedLineContainer} pointerEvents='none'>
                 <AnimatedDottedBackground
@@ -495,28 +527,31 @@ export default function CompanionScreen() {
                 {t('companion.welcomeCaption')}
               </Text>
             </View>
-          ) : (
-            <FlatList
-              ref={flatListRef}
-              data={displayMessages}
-              renderItem={renderMessage}
-              keyExtractor={keyExtractor}
-              style={styles.messagesList}
-              contentContainerStyle={styles.messagesContent}
-              ListFooterComponent={renderLoadingIndicator}
-              keyboardShouldPersistTaps='handled'
-              keyboardDismissMode='interactive'
-              initialNumToRender={10}
-              maxToRenderPerBatch={8}
-              windowSize={7}
-              updateCellsBatchingPeriod={50}
-              nestedScrollEnabled={Platform.OS === 'android'}
-              // Keep clipping disabled to avoid truncation/scroll lock for long rich bot responses on Android.
-              // Repro observed in Companion screen after response render with dynamic markdown content.
-              removeClippedSubviews={false}
-            />
-          )}
-        </Pressable>
+          </Pressable>
+        ) : (
+          <FlatList
+            ref={flatListRef}
+            data={displayMessages}
+            renderItem={renderMessage}
+            keyExtractor={keyExtractor}
+            style={styles.messagesList}
+            contentContainerStyle={styles.messagesContent}
+            ListFooterComponent={renderLoadingIndicator}
+            keyboardShouldPersistTaps='handled'
+            keyboardDismissMode='interactive'
+            onScrollBeginDrag={Keyboard.dismiss}
+            onScroll={handleScroll}
+            scrollEventThrottle={16}
+            initialNumToRender={10}
+            maxToRenderPerBatch={8}
+            windowSize={7}
+            updateCellsBatchingPeriod={50}
+            nestedScrollEnabled={Platform.OS === 'android'}
+            // Keep clipping disabled to avoid truncation/scroll lock for long rich bot responses on Android.
+            // Repro observed in Companion screen after response render with dynamic markdown content.
+            removeClippedSubviews={false}
+          />
+        )}
       </View>
 
       <Animated.View style={[styles.stickyContainer, bottomAnimatedStyle]}>


### PR DESCRIPTION
## Summary

Fixes the "can't scroll after the second question" bug in the AI Companion (~70% repro).

**Root cause:** Commit `4ceb4b9` ("fix(companion): dismiss keyboard on tap outside input") wrapped the messages region — including the `FlatList` — in a `<Pressable onPress={Keyboard.dismiss}>`. Wrapping a scrollable list in a `Pressable` creates a gesture-responder race with the list's scroll responder. After the second message there's a burst of state updates (streaming bot tokens, optimistic messages clearing, DB refetch, usage cache invalidation) firing alongside a programmatic `scrollToEnd({ animated: true })`. During that contested window the `Pressable` can grab and hold the gesture grant, leaving the list unscrollable.

The first message rarely repros because the conversation isn't yet long enough to need scrolling — it's only on the second+ message, once content overflows the viewport, that the bug becomes visible.

## Changes

- **Stop wrapping the `FlatList` in a `Pressable`** (`app/(tabs)/companion/index.tsx`). The tap-to-dismiss `Pressable` is now only used for the non-scrollable empty/loading states. The list dismisses the keyboard via the existing `keyboardDismissMode='interactive'` (drag-to-dismiss) plus `onScrollBeginDrag={Keyboard.dismiss}` (tap-and-flick).
- **Tame the auto-scroll** so it stops fighting the user:
  - Skip auto-scroll when the user has scrolled up to read earlier messages — tracked via `onScroll` + `isNearBottomRef` (80px from-bottom threshold).
  - Use `animated: false` while a bot response is streaming, so each token render doesn't kick off a new animation that conflicts with the user's gesture.
- Reset `isNearBottomRef` when switching conversations / starting a new chat so the next conversation begins pinned to the bottom.

## Test plan

- [ ] Open AI Companion, send a message, wait for response.
- [ ] Send a second message, wait for response.
- [ ] While the response is streaming, try scrolling up — gesture should work, list should not snap back to bottom.
- [ ] After the response is complete, scrolling up and down should be smooth (verify on both iOS and Android — Android historically more sensitive to nested-scroll issues).
- [ ] Tap above the input on the empty/loading states — keyboard still dismisses.
- [ ] Drag/swipe the messages list — keyboard dismisses via `keyboardDismissMode` + `onScrollBeginDrag`.
- [ ] Open a long historical conversation, scroll to the middle, then send a new message — auto-scroll should NOT yank you to the bottom (because `isNearBottomRef` is false).
- [ ] Open the same conversation pinned at the bottom and send a new message — should auto-scroll to the new content as before.
- [ ] Tap "New Chat" — empty state renders correctly, keyboard dismiss still works on tap.

https://claude.ai/code/session_01EtfodDUjLN1F9TjcCA6ppg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtfodDUjLN1F9TjcCA6ppg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-scroll behavior to intelligently activate only when scrolled near the bottom of the message list.
  * Enhanced keyboard dismissal and scroll interaction handling for smoother user experience.
  * Optimized message streaming display with refined scroll animation during bot responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/UnifyCN/mobile-app/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->