### PR TITLE
chore(posthog): drop legacy POSTHOG_API_KEY fallback

### DIFF
--- a/unify-front-end/supabase/functions/_shared/posthogCapture.ts
+++ b/unify-front-end/supabase/functions/_shared/posthogCapture.ts
@@ -60,20 +60,15 @@ function keepAlive(promise: Promise<unknown>): void {
  * Capture a PostHog `$ai_generation` event from an edge function.
  * This powers the LLM analytics dashboard (Generations view, cost tracking).
  *
- * Requires POSTHOG_API_KEY env var set in Supabase secrets.
+ * Requires POSTHOG_PROJECT_API_KEY env var (phc_...) set in Supabase secrets.
+ * /capture/ rejects Personal API Keys (phx_...) — those belong to query-API
+ * callers, not ingestion.
  */
 export function captureAiGeneration(
   distinctId: string,
   properties: AiGenerationProperties
 ): void {
-  // PostHog's /capture/ ingestion endpoint requires the Project API Key
-  // (phc_...), NOT a Personal API Key (phx_...). The two key types used to
-  // share the POSTHOG_API_KEY secret, and a personal key landed there during
-  // the interview-picker rollout — silently breaking ingestion. Read the
-  // dedicated project-key secret first; fall back to the legacy name during
-  // rollover so we don't break if both secrets aren't set yet.
-  const apiKey =
-    Deno.env.get('POSTHOG_PROJECT_API_KEY') ?? Deno.env.get('POSTHOG_API_KEY');
+  const apiKey = Deno.env.get('POSTHOG_PROJECT_API_KEY');
   if (!apiKey) {
     console.warn(
       'POSTHOG_PROJECT_API_KEY not set — skipping $ai_generation capture'

--- a/unify-front-end/supabase/functions/pick-interview-candidates/index.ts
+++ b/unify-front-end/supabase/functions/pick-interview-candidates/index.ts
@@ -16,10 +16,8 @@ const SUPABASE_SERVICE_ROLE_KEY   = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 const POSTHOG_HOST                = Deno.env.get('POSTHOG_HOST') ?? 'https://us.i.posthog.com';
 const POSTHOG_PROJECT_ID          = Deno.env.get('POSTHOG_PROJECT_ID')!;
 // HogQL queries require a Personal API Key (phx_...) with query:read scope —
-// distinct from the Project Capture Key used by event ingestion. Read the
-// dedicated secret first; fall back to the legacy POSTHOG_API_KEY during the
-// rollover window so the cron keeps running if the new secret isn't set.
-const POSTHOG_PERSONAL_API_KEY    = (Deno.env.get('POSTHOG_PERSONAL_API_KEY') ?? Deno.env.get('POSTHOG_API_KEY'))!;
+// distinct from the Project Capture Key (phc_...) used by event ingestion.
+const POSTHOG_PERSONAL_API_KEY    = Deno.env.get('POSTHOG_PERSONAL_API_KEY')!;
 const INTERVIEW_SIGNING_SECRET    = Deno.env.get('INTERVIEW_SIGNING_SECRET')!;
 const RESEND_USER_EMAILS_API_KEY  = Deno.env.get('RESEND_USER_EMAILS_API_KEY')!;
 const RESEND_INTERVIEW_FROM       = Deno.env.get('RESEND_INTERVIEW_FROM') ?? 'Savar from Unify <contact@unifysocial.ca>';


### PR DESCRIPTION
## Summary

Follow-up cleanup to #273. The fix PR split the shared \`POSTHOG_API_KEY\` Supabase secret into two correctly-scoped secrets:

- \`POSTHOG_PROJECT_API_KEY\` (\`phc_...\`) — required by \`/capture/\` ingestion (used by \`rag-query\` + \`explain-term\`).
- \`POSTHOG_PERSONAL_API_KEY\` (\`phx_...\`) — required by HogQL queries (used by \`pick-interview-candidates\`).

That PR shipped with a transitional fallback to the legacy \`POSTHOG_API_KEY\` so nothing would break if the new secrets weren't set at deploy time. They've been live for a few minutes, \`\$ai_generation\` events are flowing in PostHog, and the interview picker is happy. Time to remove the fallback so a future personal-key-vs-project-key mixup fails loudly instead of silently routing to the wrong key type.

## Test plan

- [ ] After merge, deploy \`rag-query\`, \`explain-term\`, and \`pick-interview-candidates\`.
- [ ] Send a Companion message; confirm a fresh \`\$ai_generation\` event lands in PostHog → Activity within ~10s.
- [ ] Tap "Ask AI" on a Learn term; confirm a matching \`\$ai_generation\` with \`feature: ask_ai_learn\`.
- [ ] Next interview cron run completes successfully (or manually trigger \`pick-interview-candidates\` and confirm 200).

## Manual cleanup after this merges (do in this order)

1. Merge + deploy this PR.
2. Confirm all three test-plan items above pass.
3. In Supabase Dashboard → Edge Functions → Secrets: delete \`POSTHOG_API_KEY\`.
4. In PostHog → Settings → Personal API keys: delete the over-scoped \`unify-interviewer-picker\` key (the All-access one created May 18). The new least-privilege \`supabase-edge-interview-picker\` key stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)