### PR TITLE
fix(learn): persist answers + resume position across navigation

### DIFF
--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/activities/[pageNum].tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/activities/[pageNum].tsx
@@ -201,8 +201,11 @@ export default function ActivityPageScreen() {
     // on every keystroke.
     const pageKey = currentPageData?._key;
     if (!pageKey || !lessonId || !submoduleId || !moduleId) return;
-    if (saveTimers.current[fieldKey]) clearTimeout(saveTimers.current[fieldKey]);
-    saveTimers.current[fieldKey] = setTimeout(() => {
+    // Key timers by page + field so a pending save is never cancelled by the same
+    // field key on another page.
+    const timerKey = `${pageKey}:${fieldKey}`;
+    if (saveTimers.current[timerKey]) clearTimeout(saveTimers.current[timerKey]);
+    saveTimers.current[timerKey] = setTimeout(() => {
       saveActivityInput(
         lessonId,
         submoduleId,

--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/activities/[pageNum].tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/activities/[pageNum].tsx
@@ -22,6 +22,12 @@ import {
   getLessonTotalPages,
 } from '@/utils/submoduleProgress';
 import { useLessonProgress } from '@/hooks/progress/useLessonProgress';
+import {
+  saveActivityInput,
+  getActivityInputsByPage,
+  saveResumePosition,
+  ACTIVITY_QUESTION_PREFIX,
+} from '@/services/progress/progressService';
 import { useAnalytics } from '@/utils/analytics';
 import { useFocusEffect } from '@react-navigation/native';
 
@@ -57,12 +63,49 @@ export default function ActivityPageScreen() {
     submoduleId || ''
   );
 
-  // Reset state when page changes
+  // Debounce timers for autosaving free-text inputs, keyed by field.
+  const saveTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  // Fields the user has edited on this page. Guards the async restore below from
+  // clobbering fresh input if the fetch resolves after the user starts typing.
+  const touchedRef = useRef<Set<string>>(new Set());
+
+  // Hydrate any previously-saved inputs/answers for this page so the user's work
+  // survives Next/Back and exiting/re-entering the lesson. Replaces the old effect
+  // that unconditionally wiped state to {} on every page change.
   useEffect(() => {
+    let cancelled = false;
     setIsSubmitted(false);
     setInputValues({});
     setQuestionAnswers({});
-  }, [currentPage]);
+    touchedRef.current = new Set();
+    const pageKey = lesson?.activity_pages?.[currentPage - 1]?._key;
+    if (!lessonId || !pageKey) return;
+    getActivityInputsByPage(lessonId).then(byPage => {
+      if (cancelled) return;
+      const saved = byPage[pageKey];
+      if (!saved) return;
+      // Only fill fields the user hasn't touched or already set (avoids a slow
+      // fetch overwriting input typed during the load).
+      setInputValues(prev => {
+        const next = { ...prev };
+        for (const [k, v] of Object.entries(saved.inputValues)) {
+          if (!touchedRef.current.has(k) && next[k] === undefined) next[k] = v;
+        }
+        return next;
+      });
+      setQuestionAnswers(prev => {
+        const next = { ...prev };
+        for (const [k, v] of Object.entries(saved.questionAnswers)) {
+          if (!touchedRef.current.has(k) && next[k] === undefined) next[k] = v;
+        }
+        return next;
+      });
+      if (touchedRef.current.size === 0) setIsSubmitted(saved.isSubmitted);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentPage, lessonId, lesson?.activity_pages]);
 
   // Progress tracking
   const { saveLessonCompletion } = useLessonProgress();
@@ -100,7 +143,25 @@ export default function ActivityPageScreen() {
         lastTrackedRef.current = now;
         lastTrackedPageRef.current = pageKey;
       }
-    }, [lessonTitle, lessonId, currentPage, totalPages, trackScreen])
+      // Persist resume position so exit → re-enter lands back on this activity page.
+      if (lessonId && submoduleId && moduleId) {
+        saveResumePosition(
+          lessonId,
+          submoduleId,
+          moduleId,
+          'activity',
+          currentPage
+        );
+      }
+    }, [
+      lessonTitle,
+      lessonId,
+      submoduleId,
+      moduleId,
+      currentPage,
+      totalPages,
+      trackScreen,
+    ])
   );
 
   // Helper functions for sequential navigation
@@ -134,25 +195,76 @@ export default function ActivityPageScreen() {
   };
 
   const handleInputChange = (fieldKey: string, value: string) => {
+    touchedRef.current.add(fieldKey);
     setInputValues(prev => ({ ...prev, [fieldKey]: value }));
+    // Debounced autosave of free-text so it survives navigation without a write
+    // on every keystroke.
+    const pageKey = currentPageData?._key;
+    if (!pageKey || !lessonId || !submoduleId || !moduleId) return;
+    if (saveTimers.current[fieldKey]) clearTimeout(saveTimers.current[fieldKey]);
+    saveTimers.current[fieldKey] = setTimeout(() => {
+      saveActivityInput(
+        lessonId,
+        submoduleId,
+        moduleId,
+        pageKey,
+        fieldKey,
+        value,
+        false
+      );
+    }, 600);
   };
 
   const handleQuestionAnswer = (
     questionKey: string,
     answer: string | string[]
   ) => {
+    touchedRef.current.add(questionKey);
     setQuestionAnswers(prev => ({ ...prev, [questionKey]: answer }));
+    // Selections are cheap and discrete — persist immediately.
+    const pageKey = currentPageData?._key;
+    if (!pageKey || !lessonId || !submoduleId || !moduleId) return;
+    saveActivityInput(
+      lessonId,
+      submoduleId,
+      moduleId,
+      pageKey,
+      `${ACTIVITY_QUESTION_PREFIX}${questionKey}`,
+      JSON.stringify(answer),
+      false
+    );
   };
 
   const handleSubmit = async () => {
     setIsSubmitted(true);
-    if (moduleId && submoduleId && lessonId && currentPageData?._key) {
-      trackActivityCompleted(
-        moduleId,
-        submoduleId,
-        lessonId,
-        currentPageData._key
-      );
+    const pageKey = currentPageData?._key;
+    if (moduleId && submoduleId && lessonId && pageKey) {
+      // Flush any pending debounced saves and persist final values as submitted.
+      Object.values(saveTimers.current).forEach(clearTimeout);
+      saveTimers.current = {};
+      Object.entries(inputValues).forEach(([fieldKey, value]) => {
+        saveActivityInput(
+          lessonId,
+          submoduleId,
+          moduleId,
+          pageKey,
+          fieldKey,
+          value,
+          true
+        );
+      });
+      Object.entries(questionAnswers).forEach(([questionKey, answer]) => {
+        saveActivityInput(
+          lessonId,
+          submoduleId,
+          moduleId,
+          pageKey,
+          `${ACTIVITY_QUESTION_PREFIX}${questionKey}`,
+          JSON.stringify(answer),
+          true
+        );
+      });
+      trackActivityCompleted(moduleId, submoduleId, lessonId, pageKey);
     }
   };
 

--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/quizzes/[quizId]/pages/[questionNum].tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/quizzes/[quizId]/pages/[questionNum].tsx
@@ -38,6 +38,31 @@ import { useAnalytics } from '@/utils/analytics';
 import { useFocusEffect } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 
+// Grade a single/multiple-choice answer for a given question. Module-level so it
+// can be used both in the render body and inside the attempt-resolution effect
+// (which flushes a selection made before the attempt id was ready).
+function gradeQuizAnswer(question: any, answer: string | string[]): boolean {
+  if (!question) return false;
+  if (question.question_type === 'multiple_choice_multiple') {
+    const correctIds = (
+      question.options?.filter((o: any) => o.is_correct) || []
+    ).map((o: any) => o._key);
+    const arr = Array.isArray(answer) ? answer : [];
+    return (
+      correctIds.length > 0 &&
+      correctIds.every((id: string) => arr.includes(id)) &&
+      arr.every((id: string) => correctIds.includes(id))
+    );
+  }
+  const correctAnswerId =
+    question.correct_answer?.value?.[0] || question.correct_answer?.value;
+  const single = Array.isArray(answer) ? answer[0] : answer;
+  return (
+    single === correctAnswerId ||
+    !!question.options?.find((o: any) => o._key === single)?.is_correct
+  );
+}
+
 export default function QuizQuestionPage() {
   const { moduleId, submoduleId, lessonId, quizId, questionNum } =
     useLocalSearchParams<{
@@ -84,6 +109,9 @@ export default function QuizQuestionPage() {
   // True once the user picks an answer on this question. Guards the async restore
   // from overwriting a fresh selection if getQuizResponses resolves after the tap.
   const answerTouchedRef = useRef(false);
+  // Holds a selection made before the attempt id resolved, so it still gets
+  // persisted once the attempt is ready (instead of being silently dropped).
+  const pendingAnswerRef = useRef<string | string[] | null>(null);
 
   // Progress tracking
   const { saveLessonCompletion } = useLessonProgress();
@@ -98,7 +126,23 @@ export default function QuizQuestionPage() {
       submoduleId,
       moduleId
     ).then(id => {
-      if (!cancelled) setAttemptId(id);
+      if (cancelled) return;
+      setAttemptId(id);
+      // Flush a selection the user made before the attempt id was ready.
+      const pending = pendingAnswerRef.current;
+      if (id && pending != null) {
+        const q = questions?.[currentQuestionIndex];
+        if (q?._key) {
+          submitQuizAnswer(
+            id,
+            q._key,
+            q.question_type,
+            pending,
+            gradeQuizAnswer(q, pending)
+          );
+        }
+        pendingAnswerRef.current = null;
+      }
     });
     return () => {
       cancelled = true;
@@ -294,39 +338,21 @@ export default function QuizQuestionPage() {
     );
   }
 
-  // Grade an answer with the same rules handleNext uses, so the persisted
-  // response records correctness without waiting for submission.
-  const gradeAnswer = (answer: string | string[]): boolean => {
-    if (currentQuestion.question_type === 'multiple_choice_multiple') {
-      const correctIds = (
-        currentQuestion.options?.filter((o: any) => o.is_correct) || []
-      ).map((o: any) => o._key);
-      const arr = Array.isArray(answer) ? answer : [];
-      return (
-        correctIds.length > 0 &&
-        correctIds.every((id: string) => arr.includes(id)) &&
-        arr.every((id: string) => correctIds.includes(id))
-      );
-    }
-    const correctAnswerId =
-      currentQuestion.correct_answer?.value?.[0] ||
-      currentQuestion.correct_answer?.value;
-    const single = Array.isArray(answer) ? answer[0] : answer;
-    return (
-      single === correctAnswerId ||
-      !!currentQuestion.options?.find((o: any) => o._key === single)?.is_correct
-    );
-  };
-
   // Persist the current selection against the in-progress attempt (fire-and-forget).
+  // If the attempt isn't ready yet, stash the answer so the resolution effect can
+  // flush it rather than dropping it.
   const persistSelection = (answer: string | string[]) => {
-    if (!attemptId || !currentQuestion?._key) return;
+    if (!currentQuestion?._key) return;
+    if (!attemptId) {
+      pendingAnswerRef.current = answer;
+      return;
+    }
     submitQuizAnswer(
       attemptId,
       currentQuestion._key,
       currentQuestion.question_type,
       answer,
-      gradeAnswer(answer)
+      gradeQuizAnswer(currentQuestion, answer)
     );
   };
 

--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/quizzes/[quizId]/pages/[questionNum].tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/quizzes/[quizId]/pages/[questionNum].tsx
@@ -27,6 +27,13 @@ import {
   getLessonTotalPages,
 } from '@/utils/submoduleProgress';
 import { useLessonProgress } from '@/hooks/progress/useLessonProgress';
+import {
+  getOrCreateInProgressQuizAttempt,
+  getQuizResponses,
+  submitQuizAnswer,
+  markQuizAttemptComplete,
+  saveResumePosition,
+} from '@/services/progress/progressService';
 import { useAnalytics } from '@/utils/analytics';
 import { useFocusEffect } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
@@ -71,11 +78,34 @@ export default function QuizQuestionPage() {
   );
   const [showExitModal, setShowExitModal] = useState(false);
   const [isNavigating, setIsNavigating] = useState(false);
+  // Id of the current in-progress quiz attempt; answers are saved against it so
+  // selections survive Next/Back and exiting/re-entering the quiz.
+  const [attemptId, setAttemptId] = useState<string | null>(null);
+  // True once the user picks an answer on this question. Guards the async restore
+  // from overwriting a fresh selection if getQuizResponses resolves after the tap.
+  const answerTouchedRef = useRef(false);
 
   // Progress tracking
   const { saveLessonCompletion } = useLessonProgress();
 
-  // Reset selections when question changes
+  // Resolve (or create) the in-progress attempt once per quiz.
+  useEffect(() => {
+    if (!quizId || !lessonId || !submoduleId || !moduleId) return;
+    let cancelled = false;
+    getOrCreateInProgressQuizAttempt(
+      quizId,
+      lessonId,
+      submoduleId,
+      moduleId
+    ).then(id => {
+      if (!cancelled) setAttemptId(id);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [quizId, lessonId, submoduleId, moduleId]);
+
+  // Reset selections when question changes.
   useEffect(() => {
     setSelectedAnswer(null);
     setSelectedAnswers([]);
@@ -89,7 +119,35 @@ export default function QuizQuestionPage() {
     setIncorrectLeftItems([]);
     setIncorrectRightIndices([]);
     setIsNavigating(false);
+    answerTouchedRef.current = false;
   }, [currentQuestionIndex]);
+
+  // After the reset above, restore any previously-saved selection for this
+  // question (single/multiple choice) so navigating back or re-entering the quiz
+  // keeps the user's answer. Matching questions are progressive and not restored.
+  // Quiz questions are inline Sanity array items, so their stable id is `_key`
+  // (they have no `_id`). Used as sanity_question_id for saved responses.
+  const restoreQuestionId = questions?.[currentQuestionIndex]?._key;
+  const restoreQuestionType = questions?.[currentQuestionIndex]?.question_type;
+  useEffect(() => {
+    if (!attemptId || !restoreQuestionId) return;
+    let cancelled = false;
+    getQuizResponses(attemptId).then(responses => {
+      if (cancelled || answerTouchedRef.current) return;
+      const saved = responses[restoreQuestionId];
+      if (saved === undefined || saved === null) return;
+      if (restoreQuestionType === 'multiple_choice_multiple') {
+        setSelectedAnswers(Array.isArray(saved) ? saved : [saved]);
+      } else if (restoreQuestionType !== 'matching') {
+        setSelectedAnswer(
+          Array.isArray(saved) ? String(saved[0] ?? '') : String(saved)
+        );
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [attemptId, restoreQuestionId, restoreQuestionType]);
   const totalQuestions = questions?.length || 0;
   // Get current quiz data
   const currentQuiz = quizzes?.find(q => q._id === quizId);
@@ -152,7 +210,28 @@ export default function QuizQuestionPage() {
         lastTrackedRef.current = now;
         lastTrackedPageRef.current = pageKey;
       }
-    }, [quizTitle, quizId, currentQuestionIndex, totalQuestions, trackScreen])
+      // Persist resume position so exit → re-enter lands back on this quiz question.
+      if (lessonId && submoduleId && moduleId && quizId) {
+        saveResumePosition(
+          lessonId,
+          submoduleId,
+          moduleId,
+          'quiz',
+          currentQuestionIndex + 1,
+          quizId,
+          currentQuestionIndex + 1
+        );
+      }
+    }, [
+      quizTitle,
+      quizId,
+      lessonId,
+      submoduleId,
+      moduleId,
+      currentQuestionIndex,
+      totalQuestions,
+      trackScreen,
+    ])
   );
 
   if (isLoading) {
@@ -215,21 +294,55 @@ export default function QuizQuestionPage() {
     );
   }
 
+  // Grade an answer with the same rules handleNext uses, so the persisted
+  // response records correctness without waiting for submission.
+  const gradeAnswer = (answer: string | string[]): boolean => {
+    if (currentQuestion.question_type === 'multiple_choice_multiple') {
+      const correctIds = (
+        currentQuestion.options?.filter((o: any) => o.is_correct) || []
+      ).map((o: any) => o._key);
+      const arr = Array.isArray(answer) ? answer : [];
+      return (
+        correctIds.length > 0 &&
+        correctIds.every((id: string) => arr.includes(id)) &&
+        arr.every((id: string) => correctIds.includes(id))
+      );
+    }
+    const correctAnswerId =
+      currentQuestion.correct_answer?.value?.[0] ||
+      currentQuestion.correct_answer?.value;
+    const single = Array.isArray(answer) ? answer[0] : answer;
+    return (
+      single === correctAnswerId ||
+      !!currentQuestion.options?.find((o: any) => o._key === single)?.is_correct
+    );
+  };
+
+  // Persist the current selection against the in-progress attempt (fire-and-forget).
+  const persistSelection = (answer: string | string[]) => {
+    if (!attemptId || !currentQuestion?._key) return;
+    submitQuizAnswer(
+      attemptId,
+      currentQuestion._key,
+      currentQuestion.question_type,
+      answer,
+      gradeAnswer(answer)
+    );
+  };
+
   const handleAnswerSelect = (optionId: string) => {
+    answerTouchedRef.current = true;
     if (currentQuestion.question_type === 'multiple_choice_multiple') {
       // Multiple selection logic
-      setSelectedAnswers(prev => {
-        if (prev.includes(optionId)) {
-          // Remove if already selected
-          return prev.filter(id => id !== optionId);
-        } else {
-          // Add if not selected
-          return [...prev, optionId];
-        }
-      });
+      const newAnswers = selectedAnswers.includes(optionId)
+        ? selectedAnswers.filter(id => id !== optionId)
+        : [...selectedAnswers, optionId];
+      setSelectedAnswers(newAnswers);
+      persistSelection(newAnswers);
     } else {
       // Single selection logic
       setSelectedAnswer(optionId);
+      persistSelection(optionId);
     }
   };
 
@@ -298,6 +411,8 @@ export default function QuizQuestionPage() {
 
         // Track quiz completion
         trackQuizCompletion();
+        // Close the attempt so a future visit starts fresh, not resumes old answers.
+        if (attemptId) markQuizAttemptComplete(attemptId);
 
         if (nextQuiz) {
           // Go to next quiz
@@ -422,6 +537,8 @@ export default function QuizQuestionPage() {
 
         // Track quiz completion
         trackQuizCompletion();
+        // Close the attempt so a future visit starts fresh, not resumes old answers.
+        if (attemptId) markQuizAttemptComplete(attemptId);
 
         if (nextQuiz) {
           // Go to next quiz

--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/practice/[practiceId]/activity/[pageNum].tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/practice/[practiceId]/activity/[pageNum].tsx
@@ -147,6 +147,14 @@ export default function PracticeActivityPageScreen() {
         }
         return next;
       });
+      // Restore submitted state scoped to THIS page's items (not the practice-wide
+      // aggregate) so a previously-submitted page reopens locked, not editable.
+      if (
+        touchedRef.current.size === 0 &&
+        saved.submittedKeys.some(k => pageKeys.has(k))
+      ) {
+        setIsSubmitted(true);
+      }
     });
     return () => {
       cancelled = true;
@@ -196,8 +204,11 @@ export default function PracticeActivityPageScreen() {
     touchedRef.current.add(fieldKey);
     setInputValues(prev => ({ ...prev, [fieldKey]: value }));
     if (!practiceId || !submoduleId || !moduleId) return;
-    if (saveTimers.current[fieldKey]) clearTimeout(saveTimers.current[fieldKey]);
-    saveTimers.current[fieldKey] = setTimeout(() => {
+    // Key timers by page + field so a pending save is never cancelled by the same
+    // field key on another page.
+    const timerKey = `${currentPage}:${fieldKey}`;
+    if (saveTimers.current[timerKey]) clearTimeout(saveTimers.current[timerKey]);
+    saveTimers.current[timerKey] = setTimeout(() => {
       savePracticeAnswer(
         practiceId,
         submoduleId,

--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/practice/[practiceId]/activity/[pageNum].tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/practice/[practiceId]/activity/[pageNum].tsx
@@ -20,6 +20,11 @@ import RichTextRenderer from '@/components/sanity/RichTextRenderer';
 import SubmoduleProgressBar from '@/components/learn/SubmoduleProgressBar';
 import PracticeFeedbackModal from '@/components/learn/PracticeFeedbackModal';
 import { usePracticeProgress } from '@/hooks/progress/usePracticeProgress';
+import {
+  savePracticeAnswer,
+  getPracticeAnswers,
+  PRACTICE_QUESTION_PREFIX,
+} from '@/services/progress/practiceProgressService';
 import { useTranslation } from 'react-i18next';
 
 export default function PracticeActivityPageScreen() {
@@ -100,12 +105,53 @@ export default function PracticeActivityPageScreen() {
     }, [practiceId, practice, currentPage, updatePracticeProgress])
   );
 
+  // Debounce timers for autosaving free-text inputs, keyed by field.
+  const saveTimers = React.useRef<Record<string, ReturnType<typeof setTimeout>>>(
+    {}
+  );
+  // Fields the user has edited on this page. Guards the async restore from
+  // clobbering fresh input if the fetch resolves after the user starts typing.
+  const touchedRef = React.useRef<Set<string>>(new Set());
+
+  // Hydrate previously-saved answers for this page so work survives Next/Back and
+  // exiting/re-entering the practice. Replaces the old unconditional state wipe.
   useEffect(() => {
+    let cancelled = false;
     setIsSubmitted(false);
     setInputValues({});
     setQuestionAnswers({});
     setShowFeedbackModal(false);
-  }, [currentPage]);
+    touchedRef.current = new Set();
+    if (!practiceId || !currentPageData) return;
+    getPracticeAnswers(practiceId).then(saved => {
+      if (cancelled) return;
+      // Keys are unique per block across the practice; filter to this page's blocks
+      // so we don't carry other pages' answers in local state. Only fill fields the
+      // user hasn't touched or already set.
+      const pageKeys = new Set(
+        ((currentPageData.instructions as any[]) || []).map((b: any) => b._key)
+      );
+      setInputValues(prev => {
+        const next = { ...prev };
+        for (const [k, v] of Object.entries(saved.inputValues)) {
+          if (pageKeys.has(k) && !touchedRef.current.has(k) && next[k] === undefined)
+            next[k] = v;
+        }
+        return next;
+      });
+      setQuestionAnswers(prev => {
+        const next = { ...prev };
+        for (const [k, v] of Object.entries(saved.questionAnswers)) {
+          if (pageKeys.has(k) && !touchedRef.current.has(k) && next[k] === undefined)
+            next[k] = v;
+        }
+        return next;
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentPage, practiceId, currentPageData]);
 
   const extractPlainText = useCallback((blocks: any[]): string => {
     if (!blocks || !Array.isArray(blocks)) return '';
@@ -147,18 +193,66 @@ export default function PracticeActivityPageScreen() {
   };
 
   const handleInputChange = (fieldKey: string, value: string) => {
+    touchedRef.current.add(fieldKey);
     setInputValues(prev => ({ ...prev, [fieldKey]: value }));
+    if (!practiceId || !submoduleId || !moduleId) return;
+    if (saveTimers.current[fieldKey]) clearTimeout(saveTimers.current[fieldKey]);
+    saveTimers.current[fieldKey] = setTimeout(() => {
+      savePracticeAnswer(
+        practiceId,
+        submoduleId,
+        moduleId,
+        fieldKey,
+        value,
+        false
+      );
+    }, 600);
   };
 
   const handleQuestionAnswer = (
     questionKey: string,
     answer: string | string[]
   ) => {
+    touchedRef.current.add(questionKey);
     setQuestionAnswers(prev => ({ ...prev, [questionKey]: answer }));
+    if (!practiceId || !submoduleId || !moduleId) return;
+    savePracticeAnswer(
+      practiceId,
+      submoduleId,
+      moduleId,
+      `${PRACTICE_QUESTION_PREFIX}${questionKey}`,
+      answer,
+      false
+    );
   };
 
   const handleSubmit = () => {
     setIsSubmitted(true);
+    if (practiceId && submoduleId && moduleId) {
+      // Flush pending debounced saves and persist final values as submitted.
+      Object.values(saveTimers.current).forEach(clearTimeout);
+      saveTimers.current = {};
+      Object.entries(inputValues).forEach(([fieldKey, value]) => {
+        savePracticeAnswer(
+          practiceId,
+          submoduleId,
+          moduleId,
+          fieldKey,
+          value,
+          true
+        );
+      });
+      Object.entries(questionAnswers).forEach(([questionKey, answer]) => {
+        savePracticeAnswer(
+          practiceId,
+          submoduleId,
+          moduleId,
+          `${PRACTICE_QUESTION_PREFIX}${questionKey}`,
+          answer,
+          true
+        );
+      });
+    }
 
     const userAnswerText = Object.values(inputValues).filter(Boolean).join('\n');
     if (hasTextInputs && userAnswerText.trim().length > 0) {

--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/practice/[practiceId]/pages/[questionNum].tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/practice/[practiceId]/pages/[questionNum].tsx
@@ -19,6 +19,11 @@ import { useSanityModule } from '@/hooks/sanity/useSanityModules';
 import RichTextRenderer from '@/components/sanity/RichTextRenderer';
 import SubmoduleProgressBar from '@/components/learn/SubmoduleProgressBar';
 import { usePracticeProgress } from '@/hooks/progress/usePracticeProgress';
+import {
+  savePracticeAnswer,
+  getPracticeAnswers,
+  PRACTICE_QUESTION_PREFIX,
+} from '@/services/progress/practiceProgressService';
 import { useTranslation } from 'react-i18next';
 
 function goToSubmoduleIndex(moduleId: string, submoduleId: string) {
@@ -100,6 +105,9 @@ export default function PracticeQuizQuestionPage() {
   );
   const [showExitModal, setShowExitModal] = useState(false);
   const [isNavigating, setIsNavigating] = useState(false);
+  // True once the user picks an answer on this question. Guards the async restore
+  // from overwriting a fresh selection if getPracticeAnswers resolves after the tap.
+  const answerTouchedRef = React.useRef(false);
 
   const { startPractice, updatePracticeProgress, completePractice } =
     usePracticeProgress();
@@ -132,7 +140,32 @@ export default function PracticeQuizQuestionPage() {
     setIncorrectLeftItems([]);
     setIncorrectRightIndices([]);
     setIsNavigating(false);
+    answerTouchedRef.current = false;
   }, [currentQuestionIndex]);
+
+  // Restore any previously-saved selection for this practice question so navigating
+  // back or re-entering keeps the answer. Matching questions are not restored.
+  const restoreQuestionId = questions[currentQuestionIndex]?._key;
+  const restoreQuestionType = questions[currentQuestionIndex]?.question_type;
+  useEffect(() => {
+    if (!practiceId || !restoreQuestionId) return;
+    let cancelled = false;
+    getPracticeAnswers(practiceId).then(saved => {
+      if (cancelled || answerTouchedRef.current) return;
+      const val = saved.questionAnswers[restoreQuestionId];
+      if (val === undefined || val === null) return;
+      if (restoreQuestionType === 'multiple_choice_multiple') {
+        setSelectedAnswers(Array.isArray(val) ? val : [val as string]);
+      } else if (restoreQuestionType !== 'matching') {
+        setSelectedAnswer(
+          Array.isArray(val) ? String(val[0] ?? '') : String(val)
+        );
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [practiceId, restoreQuestionId, restoreQuestionType]);
 
   const scrambledRightItems = useMemo(() => {
     const question = questions[currentQuestionIndex];
@@ -190,15 +223,30 @@ export default function PracticeQuizQuestionPage() {
 
   const isLastQuestion = currentQuestionIndex === totalQuestions - 1;
 
+  const persistPracticeSelection = (answer: string | string[]) => {
+    if (!practiceId || !submoduleId || !moduleId || !currentQuestion?._key)
+      return;
+    savePracticeAnswer(
+      practiceId,
+      submoduleId,
+      moduleId,
+      `${PRACTICE_QUESTION_PREFIX}${currentQuestion._key}`,
+      answer,
+      false
+    );
+  };
+
   const handleAnswerSelect = (optionId: string) => {
+    answerTouchedRef.current = true;
     if (currentQuestion.question_type === 'multiple_choice_multiple') {
-      setSelectedAnswers(prev =>
-        prev.includes(optionId)
-          ? prev.filter(id => id !== optionId)
-          : [...prev, optionId]
-      );
+      const newAnswers = selectedAnswers.includes(optionId)
+        ? selectedAnswers.filter(id => id !== optionId)
+        : [...selectedAnswers, optionId];
+      setSelectedAnswers(newAnswers);
+      persistPracticeSelection(newAnswers);
     } else {
       setSelectedAnswer(optionId);
+      persistPracticeSelection(optionId);
     }
   };
 

--- a/unify-front-end/services/progress/practiceProgressService.ts
+++ b/unify-front-end/services/progress/practiceProgressService.ts
@@ -152,18 +152,21 @@ export async function savePracticeAnswer(
     } = await progressClient.auth.getUser();
     if (!user) return;
 
-    const { error } = await progressClient.from(ANSWERS_TABLE).upsert(
-      {
-        user_id: user.id,
-        sanity_practice_id: practiceId,
-        sanity_submodule_id: submoduleId,
-        sanity_module_id: moduleId,
-        item_key: itemKey,
-        answer,
-        is_submitted: isSubmitted,
-      },
-      { onConflict: 'user_id,sanity_practice_id,item_key' }
-    );
+    const payload: any = {
+      user_id: user.id,
+      sanity_practice_id: practiceId,
+      sanity_submodule_id: submoduleId,
+      sanity_module_id: moduleId,
+      item_key: itemKey,
+      answer,
+    };
+    // Only a real submit writes is_submitted, so an in-flight draft autosave can
+    // never downgrade an already-submitted row back to false.
+    if (isSubmitted) payload.is_submitted = true;
+
+    const { error } = await progressClient
+      .from(ANSWERS_TABLE)
+      .upsert(payload, { onConflict: 'user_id,sanity_practice_id,item_key' });
 
     if (error) {
       console.error('Error saving practice answer:', error);
@@ -176,7 +179,11 @@ export async function savePracticeAnswer(
 export interface RestoredPracticeAnswers {
   inputValues: Record<string, string>;
   questionAnswers: Record<string, string | string[]>;
+  /** true if ANY row in the practice was submitted (practice-wide) */
   isSubmitted: boolean;
+  /** item keys (prefix-stripped) whose row was submitted, so callers can scope
+   *  submitted state to the current page instead of using the aggregate flag */
+  submittedKeys: string[];
 }
 
 /** Loads previously-saved answers for a practice so a page can rehydrate on mount. */
@@ -187,6 +194,7 @@ export async function getPracticeAnswers(
     inputValues: {},
     questionAnswers: {},
     isSubmitted: false,
+    submittedKeys: [],
   };
   try {
     const {
@@ -207,12 +215,17 @@ export async function getPracticeAnswers(
 
     for (const row of data || []) {
       const key = row.item_key as string;
-      if (row.is_submitted) empty.isSubmitted = true;
+      const strippedKey = key.startsWith(PRACTICE_QUESTION_PREFIX)
+        ? key.slice(PRACTICE_QUESTION_PREFIX.length)
+        : key;
+      if (row.is_submitted) {
+        empty.isSubmitted = true;
+        empty.submittedKeys.push(strippedKey);
+      }
       if (key.startsWith(PRACTICE_QUESTION_PREFIX)) {
-        empty.questionAnswers[key.slice(PRACTICE_QUESTION_PREFIX.length)] =
-          row.answer as string | string[];
+        empty.questionAnswers[strippedKey] = row.answer as string | string[];
       } else {
-        empty.inputValues[key] = (row.answer ?? '') as string;
+        empty.inputValues[strippedKey] = (row.answer ?? '') as string;
       }
     }
     return empty;

--- a/unify-front-end/services/progress/practiceProgressService.ts
+++ b/unify-front-end/services/progress/practiceProgressService.ts
@@ -128,6 +128,100 @@ export async function updatePracticeProgress(
   }
 }
 
+// =============================================
+// PRACTICE ANSWER PERSISTENCE (typed inputs + selections)
+// Stored in user_practice_answers. item_key = Sanity block _key, prefixed with
+// PRACTICE_QUESTION_PREFIX for multiple-choice answers so restore can route each
+// value back to the right state map (a block is only ever an input OR a question).
+// =============================================
+
+const ANSWERS_TABLE = 'user_practice_answers';
+export const PRACTICE_QUESTION_PREFIX = 'q::';
+
+export async function savePracticeAnswer(
+  practiceId: string,
+  submoduleId: string,
+  moduleId: string,
+  itemKey: string,
+  answer: string | string[],
+  isSubmitted = false
+): Promise<void> {
+  try {
+    const {
+      data: { user },
+    } = await progressClient.auth.getUser();
+    if (!user) return;
+
+    const { error } = await progressClient.from(ANSWERS_TABLE).upsert(
+      {
+        user_id: user.id,
+        sanity_practice_id: practiceId,
+        sanity_submodule_id: submoduleId,
+        sanity_module_id: moduleId,
+        item_key: itemKey,
+        answer,
+        is_submitted: isSubmitted,
+      },
+      { onConflict: 'user_id,sanity_practice_id,item_key' }
+    );
+
+    if (error) {
+      console.error('Error saving practice answer:', error);
+    }
+  } catch (error) {
+    console.error('Error in savePracticeAnswer:', error);
+  }
+}
+
+export interface RestoredPracticeAnswers {
+  inputValues: Record<string, string>;
+  questionAnswers: Record<string, string | string[]>;
+  isSubmitted: boolean;
+}
+
+/** Loads previously-saved answers for a practice so a page can rehydrate on mount. */
+export async function getPracticeAnswers(
+  practiceId: string
+): Promise<RestoredPracticeAnswers> {
+  const empty: RestoredPracticeAnswers = {
+    inputValues: {},
+    questionAnswers: {},
+    isSubmitted: false,
+  };
+  try {
+    const {
+      data: { user },
+    } = await progressClient.auth.getUser();
+    if (!user) return empty;
+
+    const { data, error } = await progressClient
+      .from(ANSWERS_TABLE)
+      .select('item_key, answer, is_submitted')
+      .eq('user_id', user.id)
+      .eq('sanity_practice_id', practiceId);
+
+    if (error) {
+      console.error('Error fetching practice answers:', error);
+      return empty;
+    }
+
+    for (const row of data || []) {
+      const key = row.item_key as string;
+      if (row.is_submitted) empty.isSubmitted = true;
+      if (key.startsWith(PRACTICE_QUESTION_PREFIX)) {
+        empty.questionAnswers[key.slice(PRACTICE_QUESTION_PREFIX.length)] =
+          row.answer as string | string[];
+      } else {
+        empty.inputValues[key] = (row.answer ?? '') as string;
+      }
+    }
+    return empty;
+  } catch (error) {
+    console.error('Error in getPracticeAnswers:', error);
+    return empty;
+  }
+}
+
 export async function completePractice(practiceId: string): Promise<void> {
   try {
     const {

--- a/unify-front-end/services/progress/progressService.ts
+++ b/unify-front-end/services/progress/progressService.ts
@@ -159,6 +159,57 @@ export async function updateLessonProgress(
   }
 }
 
+/**
+ * Persists ONLY the resume position (current page/quiz/question) without touching
+ * progress_percent / completed_pages. `updateLessonProgress` conflates position with
+ * the progress bar, which is fine for reading pages (page index == cumulative index)
+ * but WRONG for activities/quizzes, where the within-section index is smaller than the
+ * cumulative one and would drag the bar backwards. Use this from activity/quiz pages so
+ * learnHref can resume the user to the exact spot without regressing their progress.
+ */
+export async function saveResumePosition(
+  lessonId: string,
+  submoduleId: string,
+  moduleId: string,
+  pageType: 'intro' | 'lesson' | 'activity' | 'quiz',
+  pageNumber: number,
+  quizId?: string,
+  questionNumber?: number
+): Promise<void> {
+  try {
+    if (!lessonId || !submoduleId || !moduleId) return;
+    const {
+      data: { user },
+    } = await progressClient.auth.getUser();
+    if (!user) return;
+
+    const upsertData: any = {
+      user_id: user.id,
+      sanity_lesson_id: lessonId,
+      sanity_submodule_id: submoduleId,
+      sanity_module_id: moduleId,
+      is_in_progress: true,
+      current_page_type: pageType,
+      current_page_number: pageNumber,
+      last_accessed_at: new Date().toISOString(),
+    };
+    if (quizId) upsertData.current_quiz_id = quizId;
+    if (questionNumber) upsertData.current_question_number = questionNumber;
+
+    const { error } = await progressClient
+      .from('user_lesson_progress')
+      .upsert(upsertData, { onConflict: 'user_id,sanity_lesson_id' });
+
+    if (error) {
+      console.error('Error saving resume position:', error);
+    } else {
+      progressEventEmitter.emit();
+    }
+  } catch (error) {
+    console.error('Error in saveResumePosition:', error);
+  }
+}
+
 async function completeLesson(lessonId: string): Promise<void> {
   try {
     const {
@@ -275,7 +326,7 @@ async function completePage(
 // QUIZ PROGRESS SERVICE
 // =============================================
 
-async function startQuizAttempt(
+export async function startQuizAttempt(
   quizId: string,
   lessonId: string,
   submoduleId: string,
@@ -326,7 +377,101 @@ async function startQuizAttempt(
   }
 }
 
-async function submitQuizAnswer(
+/**
+ * Returns the id of the current *in-progress* (not-yet-completed) quiz attempt for
+ * this user+quiz, creating one if none exists. Used to resume a quiz so selections
+ * persist across question navigation and exit/re-entry within the same attempt.
+ */
+export async function getOrCreateInProgressQuizAttempt(
+  quizId: string,
+  lessonId: string,
+  submoduleId: string,
+  moduleId: string
+): Promise<string | null> {
+  try {
+    const {
+      data: { user },
+    } = await progressClient.auth.getUser();
+    if (!user) return null;
+
+    const { data: existing, error: fetchError } = await progressClient
+      .from('user_quiz_attempts')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('sanity_quiz_id', quizId)
+      .is('completed_at', null)
+      .order('attempt_number', { ascending: false })
+      .limit(1);
+
+    if (fetchError) {
+      console.error('Error fetching in-progress quiz attempt:', fetchError);
+      return null;
+    }
+
+    if (existing?.[0]?.id) return existing[0].id;
+
+    const created = await startQuizAttempt(
+      quizId,
+      lessonId,
+      submoduleId,
+      moduleId
+    );
+    if (created) return created;
+
+    // Creation may have lost a race to a concurrent mount (two question pages
+    // inserting attempt_number=1 → unique violation → startQuizAttempt returns
+    // null). Re-read once so we still land on the attempt the other mount created.
+    const { data: retry } = await progressClient
+      .from('user_quiz_attempts')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('sanity_quiz_id', quizId)
+      .is('completed_at', null)
+      .order('attempt_number', { ascending: false })
+      .limit(1);
+
+    return retry?.[0]?.id ?? null;
+  } catch (error) {
+    console.error('Error in getOrCreateInProgressQuizAttempt:', error);
+    return null;
+  }
+}
+
+/** Loads saved answers for a quiz attempt, keyed by sanity question id. */
+export async function getQuizResponses(
+  attemptId: string
+): Promise<Record<string, any>> {
+  try {
+    const {
+      data: { user },
+    } = await progressClient.auth.getUser();
+    if (!user) return {};
+
+    const { data, error } = await progressClient
+      .from('user_quiz_responses')
+      .select('sanity_question_id, user_answer')
+      .eq('user_id', user.id)
+      .eq('quiz_attempt_id', attemptId);
+
+    if (error) {
+      console.error('Error fetching quiz responses:', error);
+      return {};
+    }
+
+    const result: Record<string, any> = {};
+    for (const row of data || []) {
+      if (row?.sanity_question_id) {
+        result[row.sanity_question_id] = row.user_answer;
+      }
+    }
+    return result;
+  } catch (error) {
+    console.error('Error in getQuizResponses:', error);
+    return {};
+  }
+}
+
+export async function submitQuizAnswer(
   attemptId: string,
   questionId: string,
   questionType: string,
@@ -362,7 +507,28 @@ async function submitQuizAnswer(
   }
 }
 
-async function completeQuizAttempt(
+/**
+ * Closes an in-progress quiz attempt (sets completed_at) so the NEXT visit to the
+ * quiz starts a fresh attempt instead of resuming old answers. Kept separate from
+ * completeQuizAttempt so we don't have to fabricate a score just to close it.
+ */
+export async function markQuizAttemptComplete(attemptId: string): Promise<void> {
+  try {
+    if (!attemptId) return;
+    const { error } = await progressClient
+      .from('user_quiz_attempts')
+      .update({ completed_at: new Date().toISOString() })
+      .eq('id', attemptId)
+      .is('completed_at', null);
+    if (error) {
+      console.error('Error marking quiz attempt complete:', error);
+    }
+  } catch (error) {
+    console.error('Error in markQuizAttemptComplete:', error);
+  }
+}
+
+export async function completeQuizAttempt(
   attemptId: string,
   score: number,
   totalQuestions: number,
@@ -392,13 +558,20 @@ async function completeQuizAttempt(
 // ACTIVITY INPUT SERVICE
 // =============================================
 
-async function saveActivityInput(
+// Prefix used to distinguish embedded multiple-choice question answers (which can
+// be string | string[], stored JSON-encoded) from free-text inputs (plain string)
+// within the single user_activity_inputs.input_value text column. A given Sanity
+// block _key is only ever an input OR a question, never both.
+export const ACTIVITY_QUESTION_PREFIX = 'q::';
+
+export async function saveActivityInput(
   lessonId: string,
   submoduleId: string,
   moduleId: string,
   pageKey: string,
   fieldKey: string,
-  value: string
+  value: string,
+  isSubmitted = false
 ): Promise<void> {
   try {
     const {
@@ -415,8 +588,8 @@ async function saveActivityInput(
         activity_page_key: pageKey,
         input_field_key: fieldKey,
         input_value: value,
-        is_submitted: true,
-        submitted_at: new Date().toISOString(),
+        is_submitted: isSubmitted,
+        submitted_at: isSubmitted ? new Date().toISOString() : null,
       },
       {
         onConflict:
@@ -429,5 +602,74 @@ async function saveActivityInput(
     }
   } catch (error) {
     console.error('Error in saveActivityInput:', error);
+  }
+}
+
+export interface RestoredActivityInputs {
+  /** free-text inputs keyed by block _key */
+  inputValues: Record<string, string>;
+  /** embedded question answers keyed by block _key */
+  questionAnswers: Record<string, string | string[]>;
+  /** whether any saved row on this page was already submitted */
+  isSubmitted: boolean;
+}
+
+/**
+ * Loads previously-saved activity inputs/answers for a lesson, grouped by
+ * activity page key, so a page can rehydrate its state on mount.
+ * Returns {} when the user is signed out or nothing was saved.
+ */
+export async function getActivityInputsByPage(
+  lessonId: string
+): Promise<Record<string, RestoredActivityInputs>> {
+  try {
+    const {
+      data: { user },
+    } = await progressClient.auth.getUser();
+    if (!user) return {};
+
+    const { data, error } = await progressClient
+      .from('user_activity_inputs')
+      .select(
+        'activity_page_key, input_field_key, input_value, is_submitted'
+      )
+      .eq('user_id', user.id)
+      .eq('sanity_lesson_id', lessonId);
+
+    if (error) {
+      console.error('Error fetching activity inputs:', error);
+      return {};
+    }
+
+    const result: Record<string, RestoredActivityInputs> = {};
+    for (const row of data || []) {
+      const pageKey = row.activity_page_key as string;
+      if (!result[pageKey]) {
+        result[pageKey] = {
+          inputValues: {},
+          questionAnswers: {},
+          isSubmitted: false,
+        };
+      }
+      const bucket = result[pageKey];
+      if (row.is_submitted) bucket.isSubmitted = true;
+
+      const fieldKey = row.input_field_key as string;
+      const raw = (row.input_value ?? '') as string;
+      if (fieldKey.startsWith(ACTIVITY_QUESTION_PREFIX)) {
+        const blockKey = fieldKey.slice(ACTIVITY_QUESTION_PREFIX.length);
+        try {
+          bucket.questionAnswers[blockKey] = JSON.parse(raw);
+        } catch {
+          bucket.questionAnswers[blockKey] = raw;
+        }
+      } else {
+        bucket.inputValues[fieldKey] = raw;
+      }
+    }
+    return result;
+  } catch (error) {
+    console.error('Error in getActivityInputsByPage:', error);
+    return {};
   }
 }

--- a/unify-front-end/services/progress/progressService.ts
+++ b/unify-front-end/services/progress/progressService.ts
@@ -579,23 +579,29 @@ export async function saveActivityInput(
     } = await progressClient.auth.getUser();
     if (!user) return;
 
-    const { error } = await progressClient.from('user_activity_inputs').upsert(
-      {
-        user_id: user.id,
-        sanity_lesson_id: lessonId,
-        sanity_submodule_id: submoduleId,
-        sanity_module_id: moduleId,
-        activity_page_key: pageKey,
-        input_field_key: fieldKey,
-        input_value: value,
-        is_submitted: isSubmitted,
-        submitted_at: isSubmitted ? new Date().toISOString() : null,
-      },
-      {
+    const payload: any = {
+      user_id: user.id,
+      sanity_lesson_id: lessonId,
+      sanity_submodule_id: submoduleId,
+      sanity_module_id: moduleId,
+      activity_page_key: pageKey,
+      input_field_key: fieldKey,
+      input_value: value,
+    };
+    // Only a real submit writes is_submitted, so an in-flight draft autosave can
+    // never downgrade an already-submitted row back to false (upsert leaves
+    // columns absent from the payload untouched on conflict).
+    if (isSubmitted) {
+      payload.is_submitted = true;
+      payload.submitted_at = new Date().toISOString();
+    }
+
+    const { error } = await progressClient
+      .from('user_activity_inputs')
+      .upsert(payload, {
         onConflict:
           'user_id,sanity_lesson_id,activity_page_key,input_field_key',
-      }
-    );
+      });
 
     if (error) {
       console.error('Error saving activity input:', error);

--- a/unify-front-end/supabase/migrations/20260705_user_practice_answers.sql
+++ b/unify-front-end/supabase/migrations/20260705_user_practice_answers.sql
@@ -1,0 +1,39 @@
+-- Persists per-user answers for Practice sections (typed inputs AND multiple-choice
+-- selections) so they survive navigating between pages and exiting/re-entering.
+-- Learn *lessons* already have user_activity_inputs + user_quiz_responses; Practice
+-- had only user_practice_progress (page number), with no home for the answers.
+-- One row per (user, practice, item). item_key = Sanity block _key. answer holds a
+-- string (typed input) or string/string[] (selection), stored as jsonb.
+create table if not exists public.user_practice_answers (
+  id                  uuid primary key default gen_random_uuid(),
+  user_id             uuid not null references auth.users(id) on delete cascade,
+  sanity_practice_id  text not null,
+  sanity_submodule_id text not null,
+  sanity_module_id    text not null,
+  item_key            text not null,
+  answer              jsonb,
+  is_submitted        boolean not null default false,
+  created_at          timestamptz not null default timezone('utc', now()),
+  updated_at          timestamptz not null default timezone('utc', now()),
+  unique (user_id, sanity_practice_id, item_key)
+);
+
+create index if not exists user_practice_answers_user_practice_idx
+  on public.user_practice_answers (user_id, sanity_practice_id);
+
+alter table public.user_practice_answers enable row level security;
+
+-- Owner-only access (mirrors user_practice_progress / user_activity_inputs policies).
+-- drop-then-create keeps the file replayable (already applied out-of-band in prod).
+drop policy if exists "Users manage own practice answers" on public.user_practice_answers;
+create policy "Users manage own practice answers"
+  on public.user_practice_answers for all
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Reuse the shared updated_at trigger fn created by the practice_progress migration.
+drop trigger if exists user_practice_answers_updated_at on public.user_practice_answers;
+create trigger user_practice_answers_updated_at
+  before update on public.user_practice_answers
+  for each row execute function public.set_updated_at();


### PR DESCRIPTION
## Problem

From the June 25 Luis/Savar sync: typed answers, quiz selections, and practice inputs vanished when a user pressed **Next -> Back** or **exited -> re-entered** a Learn lesson. Every module, both web and mobile.

Root cause was entirely client-side:
- The Supabase writers (`saveActivityInput`, quiz attempt/response writers) existed but were **never called** - dead code.
- Every page ran a `useEffect` that **wiped answer state to `{}`** on page change.
- Navigation uses `router.push` (fresh mount) with **no restore-on-mount**.

## What changed

**Lessons (tables already existed):**
- Wire + restore activity typed inputs and embedded questions (`user_activity_inputs`).
- Quiz selections persisted/restored against an in-progress attempt (`user_quiz_attempts` / `user_quiz_responses`).

**Practice (new table):**
- `user_practice_answers` migration - one row per `(user, practice, item)`, `answer jsonb`, owner RLS. Holds both typed inputs and selections.

**Resume:**
- `saveResumePosition` writes only the position columns, so the progress bar never regresses. `learnHref` already routes from `current_page_*`.

**Correctness:**
- Inline Sanity questions are keyed by `_key`, not `_id` (which is `undefined` at runtime - `getQuizQuestions` returns `any[]`).
- Async restore guarded by a per-field "touched" ref so a slow fetch can't clobber input the user just typed.
- Quiz-attempt creation retries on the unique-constraint race.

## Verification

- `tsc --noEmit` clean; eslint 0 errors (pre-existing warnings only).
- DB schema/constraints/RLS verified against prod; migration applied (`20260705_user_practice_answers.sql`) and round-trip-tested.
- Reviewed by two independent agents (adversarial + data-layer); their findings fixed in this branch.

**Not yet done:** on-device behavioral test (type in activity -> Next/Back -> exit/re-enter; same for quiz + practice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Learning, practice, and quiz screens now save progress automatically and restore your last answers when you return.
  * Quiz and practice sessions now resume on the same question or page you left off.
  * Submitted answers are now preserved so completed work stays intact across navigation.

* **Bug Fixes**
  * Fixed answers being cleared when moving between pages.
  * Prevented saved responses from overwriting newly entered input.
  * Improved consistency for multiple-choice, text, and matching question handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->