### PR TITLE
Fix Companion quota RPC permissions

### DIFF
--- a/unify-front-end/supabase/migrations/20260816215836_restrict_chatbot_usage_rpc_execution.sql
+++ b/unify-front-end/supabase/migrations/20260816215836_restrict_chatbot_usage_rpc_execution.sql
@@ -1,0 +1,66 @@
+-- These quota bookkeeping RPCs are internal server operations. Keeping EXECUTE
+-- limited to service_role prevents clients from supplying another user's ID.
+revoke execute
+  on function public.check_and_increment_chatbot_usage(uuid, integer)
+  from public, anon, authenticated;
+
+revoke execute
+  on function public.increment_chatbot_usage(uuid, bigint, double precision)
+  from public, anon, authenticated;
+
+revoke execute
+  on function public.refund_chatbot_message(uuid)
+  from public, anon, authenticated;
+
+grant execute
+  on function public.check_and_increment_chatbot_usage(uuid, integer)
+  to service_role;
+
+grant execute
+  on function public.increment_chatbot_usage(uuid, bigint, double precision)
+  to service_role;
+
+grant execute
+  on function public.refund_chatbot_message(uuid)
+  to service_role;
+
+-- Fail this migration immediately if any effective privilege is not as intended.
+-- PUBLIC is a pseudo-role, so inspect the expanded ACL instead of passing it to
+-- has_function_privilege.
+do $$
+declare
+  target regprocedure;
+begin
+  foreach target in array array[
+    'public.check_and_increment_chatbot_usage(uuid,integer)'::regprocedure,
+    'public.increment_chatbot_usage(uuid,bigint,double precision)'::regprocedure,
+    'public.refund_chatbot_message(uuid)'::regprocedure
+  ]
+  loop
+    if exists (
+      select 1
+      from pg_catalog.pg_proc as p
+      cross join lateral pg_catalog.aclexplode(
+        coalesce(p.proacl, pg_catalog.acldefault('f', p.proowner))
+      ) as a
+      where p.oid = target::oid
+        and a.grantee = 0
+        and a.privilege_type = 'EXECUTE'
+    ) then
+      raise exception 'PUBLIC still has EXECUTE on %', target;
+    end if;
+
+    if pg_catalog.has_function_privilege('anon', target::oid, 'execute') then
+      raise exception 'anon still has EXECUTE on %', target;
+    end if;
+
+    if pg_catalog.has_function_privilege('authenticated', target::oid, 'execute') then
+      raise exception 'authenticated still has EXECUTE on %', target;
+    end if;
+
+    if not pg_catalog.has_function_privilege('service_role', target::oid, 'execute') then
+      raise exception 'service_role does not have EXECUTE on %', target;
+    end if;
+  end loop;
+end
+$$;

--- a/unify-front-end/supabase/tests/restrict_chatbot_usage_rpc_execution_test.sql
+++ b/unify-front-end/supabase/tests/restrict_chatbot_usage_rpc_execution_test.sql
@@ -1,0 +1,69 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set local search_path = extensions, public;
+
+select plan(12);
+
+with targets(name, signature) as (
+  values
+    (
+      'check_and_increment_chatbot_usage',
+      'public.check_and_increment_chatbot_usage(uuid,integer)'::regprocedure
+    ),
+    (
+      'increment_chatbot_usage',
+      'public.increment_chatbot_usage(uuid,bigint,double precision)'::regprocedure
+    ),
+    (
+      'refund_chatbot_message',
+      'public.refund_chatbot_message(uuid)'::regprocedure
+    )
+),
+expected(role_name, can_execute) as (
+  values
+    ('public', false),
+    ('anon', false),
+    ('authenticated', false),
+    ('service_role', true)
+),
+actual as (
+  select
+    targets.name,
+    expected.role_name,
+    expected.can_execute,
+    case
+      when expected.role_name = 'public' then exists (
+        select 1
+        from pg_catalog.pg_proc as p
+        cross join lateral pg_catalog.aclexplode(
+          coalesce(p.proacl, pg_catalog.acldefault('f', p.proowner))
+        ) as a
+        where p.oid = targets.signature::oid
+          and a.grantee = 0
+          and a.privilege_type = 'EXECUTE'
+      )
+      else pg_catalog.has_function_privilege(
+        expected.role_name::name,
+        targets.signature::oid,
+        'execute'
+      )
+    end as can_actually_execute
+  from targets
+  cross join expected
+)
+select ok(
+  can_actually_execute is not distinct from can_execute,
+  format(
+    '%s EXECUTE on %s is %s',
+    role_name,
+    name,
+    case when can_execute then 'granted' else 'revoked' end
+  )
+)
+from actual
+order by name, role_name;
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Link

P0 shared-backend reconciliation; no issue was provided.

## What was done

- Revoke `EXECUTE` on the three Companion quota bookkeeping RPCs from `PUBLIC`, `anon`, and `authenticated`.
- Preserve access for `service_role`, which is the only role used by the mobile and web `rag-query` Edge Function call paths.
- Fail the migration if any effective privilege differs from the intended matrix.
- Add 12 pgTAP assertions covering three exact signatures across four roles.

## Why

Production currently grants both `anon` and `authenticated` direct execution on `SECURITY DEFINER` functions that accept a caller-supplied user ID. A client can therefore mutate another user quota bookkeeping directly. The mobile and web apps do not call these RPCs from client credentials, so restricting them to `service_role` preserves the supported call path.

## Validation

- `git diff --check`
- Two independent static reviews: no correctness, scope, or repository-standard findings
- The exact 12-case privilege query compiled against production in read-only mode
- Current production matrix confirmed: `PUBLIC=false`, `anon=true`, `authenticated=true`, `service_role=true` for all three RPCs
- Local pgTAP execution was not possible because Docker is unavailable and the existing migration history is not replayable from a blank reset; CI and post-deploy live verification remain required

## Frontend Screenshots

Not applicable; no UI or runtime code changed.

## Deployment note

Do not use a bulk `supabase db push` from the current repository history. After merge, apply this migration through a version-preserving path, then verify direct anon/authenticated RPC denial and the service-role Companion increment/refund flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted chatbot usage operations to authorized backend services.
  * Prevented public and authenticated client roles from directly executing chatbot usage operations.
* **Tests**
  * Added coverage to verify execution permissions remain correctly enforced across client and service roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->