### PR TITLE
Add safe translated Sanity content to mobile

### DIFF
--- a/unify-front-end/__tests__/sanity/checklistCache.test.ts
+++ b/unify-front-end/__tests__/sanity/checklistCache.test.ts
@@ -1,0 +1,34 @@
+import {
+  buildChecklistCacheStorageKey,
+  getChecklistMemoryCache,
+  loadChecklistFromDisk,
+  saveChecklistToDisk,
+  setChecklistMemoryCache,
+} from '@/utils/checklistTaskCache';
+
+const tasks = [{ sanity_checklist_id: 'task-1' }] as any;
+
+describe('checklist translation cache freshness', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('expires memory and persisted content so newly published translations revalidate', async () => {
+    const now = 1_700_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
+    const key = buildChecklistCacheStorageKey(
+      'cache-test-user',
+      1,
+      'skilled_worker',
+      false,
+      'es'
+    );
+
+    setChecklistMemoryCache(key, tasks);
+    await saveChecklistToDisk(key, tasks);
+    expect(getChecklistMemoryCache(key)).toEqual(tasks);
+    expect(await loadChecklistFromDisk(key)).toEqual(tasks);
+
+    nowSpy.mockReturnValue(now + 11 * 60 * 1000);
+    expect(getChecklistMemoryCache(key)).toBeUndefined();
+    await expect(loadChecklistFromDisk(key)).resolves.toBeNull();
+  });
+});

--- a/unify-front-end/__tests__/sanity/checklistOfflineRevalidation.test.tsx
+++ b/unify-front-end/__tests__/sanity/checklistOfflineRevalidation.test.tsx
@@ -1,0 +1,97 @@
+import type { PropsWithChildren } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+jest.mock('@/hooks/sanity/useSanityLanguage', () => ({
+  useSanityLanguage: () => 'es',
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }),
+    },
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          order: jest.fn().mockResolvedValue({ data: [], error: null }),
+        })),
+      })),
+    })),
+  },
+}));
+
+jest.mock('@/sanity-custom', () => ({
+  sanityClient: { fetch: jest.fn() },
+}));
+
+import { sanityClient } from '@/sanity-custom';
+import { useChecklistTasks } from '@/hooks/checklist/useChecklistTasks';
+import {
+  buildChecklistCacheStorageKey,
+  loadChecklistFromDisk,
+  saveChecklistToDisk,
+} from '@/utils/checklistTaskCache';
+
+const mockFetch = sanityClient.fetch as jest.Mock;
+const cachedTasks = [
+  {
+    user_task_id: 0,
+    user_id: 'user-1',
+    task_id: null,
+    custom_task_id: null,
+    sanity_checklist_id: 'checklist-base',
+    completed: false,
+    completed_at: null,
+    source: 'sanity',
+    task: {
+      task_name: 'Tarea guardada',
+      task_description: 'Disponible sin conexión',
+      priority: 'Do now',
+    },
+  },
+] as any;
+
+describe('checklist offline revalidation', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('keeps same-language hydrated tasks when Sanity revalidation fails', async () => {
+    const key = buildChecklistCacheStorageKey(
+      'user-1',
+      1,
+      'skilled_worker',
+      false,
+      'es'
+    );
+    await saveChecklistToDisk(key, cachedTasks);
+    mockFetch.mockRejectedValue(new Error('offline'));
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    const { result, unmount } = renderHook(
+      () =>
+        useChecklistTasks({
+          currentStage: 1,
+          stageChanged: false,
+          persona: 'skilled_worker',
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() =>
+      expect(result.current.tasks[0]?.task.task_name).toBe('Tarea guardada')
+    );
+    await waitFor(() => expect(result.current.error).toContain('offline'));
+    expect(result.current.tasks).toEqual(cachedTasks);
+    await expect(loadChecklistFromDisk(key)).resolves.toEqual(cachedTasks);
+
+    unmount();
+    client.clear();
+    consoleSpy.mockRestore();
+  });
+});

--- a/unify-front-end/__tests__/sanity/contentServices.test.ts
+++ b/unify-front-end/__tests__/sanity/contentServices.test.ts
@@ -6,11 +6,14 @@ import { sanityClient } from '@/sanity-custom';
 import { getModuleWithSubmodules } from '@/services/sanity/modules';
 import { getSubmoduleWithLessons } from '@/services/sanity/submodules';
 import { getPracticesBySubmodule } from '@/services/sanity/practices';
-import { getLessonQuizzes } from '@/services/sanity/quizzes';
+import { getLessonQuizzes, getQuizQuestions } from '@/services/sanity/quizzes';
 import { getTaskById } from '@/services/sanity/tasks';
 import { getChecklistByPersonaAndStage } from '@/services/sanity/checklist';
 
 const mockFetch = sanityClient.fetch as jest.Mock;
+
+type NotAny<T> = 0 extends 1 & T ? never : T;
+type QuizQuestionResult = Awaited<ReturnType<typeof getQuizQuestions>>[number];
 
 describe('translated Sanity service contracts', () => {
   beforeEach(() => mockFetch.mockReset());
@@ -161,6 +164,44 @@ describe('translated Sanity service contracts', () => {
     });
   });
 
+  it('returns a typed translated question shape from the question service', async () => {
+    mockFetch.mockResolvedValue({
+      questions: [
+        {
+          _key: 'question-1',
+          question_type: 'multiple_choice_single',
+          question_text: [],
+          order_number: 1,
+          options: [
+            {
+              _key: 'option-a',
+              text: [],
+              value: 'a',
+              is_correct: true,
+            },
+          ],
+        },
+      ],
+      i18n: {
+        questions: [
+          {
+            _key: 'question-1',
+            question_text: [],
+            options: [{ _key: 'option-a', text: [] }],
+          },
+        ],
+      },
+    });
+
+    const questions = await getQuizQuestions('quiz-base', 'es');
+    const typedQuestion: NotAny<QuizQuestionResult> = questions[0];
+    expect(typedQuestion).toMatchObject({
+      _key: 'question-1',
+      question_type: 'multiple_choice_single',
+      options: [{ _key: 'option-a', value: 'a', is_correct: true }],
+    });
+  });
+
   it('overlays task and checklist text while retaining persistence ids', async () => {
     mockFetch
       .mockResolvedValueOnce({
@@ -196,5 +237,28 @@ describe('translated Sanity service contracts', () => {
       _id: 'checklist-base',
       title: 'قائمة',
     });
+  });
+
+  it('rejects a failed forced checklist refresh even after an empty success', async () => {
+    mockFetch
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error('network unavailable'));
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    await expect(
+      getChecklistByPersonaAndStage('other', 'years_3_plus', {
+        language: 'vi',
+      })
+    ).resolves.toEqual([]);
+    await expect(
+      getChecklistByPersonaAndStage('other', 'years_3_plus', {
+        language: 'vi',
+        skipCache: true,
+      })
+    ).rejects.toThrow('network unavailable');
+
+    consoleSpy.mockRestore();
   });
 });

--- a/unify-front-end/__tests__/sanity/contentServices.test.ts
+++ b/unify-front-end/__tests__/sanity/contentServices.test.ts
@@ -1,0 +1,200 @@
+jest.mock('@/sanity-custom', () => ({
+  sanityClient: { fetch: jest.fn() },
+}));
+
+import { sanityClient } from '@/sanity-custom';
+import { getModuleWithSubmodules } from '@/services/sanity/modules';
+import { getSubmoduleWithLessons } from '@/services/sanity/submodules';
+import { getPracticesBySubmodule } from '@/services/sanity/practices';
+import { getLessonQuizzes } from '@/services/sanity/quizzes';
+import { getTaskById } from '@/services/sanity/tasks';
+import { getChecklistByPersonaAndStage } from '@/services/sanity/checklist';
+
+const mockFetch = sanityClient.fetch as jest.Mock;
+
+describe('translated Sanity service contracts', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('preserves module, submodule, lesson and quiz identities', async () => {
+    mockFetch.mockResolvedValue({
+      _id: 'module-base',
+      title: 'Module',
+      i18n: { _id: 'module-es', title: 'Módulo' },
+      submodules: [
+        {
+          _id: 'submodule-base',
+          title: 'Section',
+          i18n: { _id: 'submodule-es', title: 'Sección' },
+          lessons: [
+            {
+              _id: 'lesson-base',
+              title: 'Lesson',
+              i18n: { _id: 'lesson-es', title: 'Lección' },
+              quizzes: [
+                {
+                  _id: 'quiz-base',
+                  title: 'Quiz',
+                  i18n: { _id: 'quiz-es', title: 'Prueba' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await getModuleWithSubmodules('module-base', 'es');
+    expect(result).toMatchObject({
+      _id: 'module-base',
+      title: 'Módulo',
+      submodules: [
+        {
+          _id: 'submodule-base',
+          title: 'Sección',
+          lessons: [
+            {
+              _id: 'lesson-base',
+              title: 'Lección',
+              quizzes: [{ _id: 'quiz-base', title: 'Prueba' }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(mockFetch.mock.calls[0][1]).toEqual({
+      moduleId: 'module-base',
+      lang: 'es',
+    });
+  });
+
+  it('preserves submodule lesson keys through its direct service', async () => {
+    mockFetch.mockResolvedValue({
+      _id: 'submodule-base',
+      title: 'Section',
+      intro_pages: [{ _key: 'intro-1', title: 'Base intro' }],
+      i18n: {
+        _id: 'submodule-fr',
+        title: 'Section française',
+        intro_pages: [{ _key: 'intro-1', title: 'Introduction' }],
+      },
+      lessons: [{ _id: 'lesson-base', title: 'Base lesson' }],
+    });
+
+    const result = await getSubmoduleWithLessons('submodule-base', 'fr-CA');
+    expect(result?._id).toBe('submodule-base');
+    expect(result?.intro_pages?.[0]).toMatchObject({
+      _key: 'intro-1',
+      title: 'Introduction',
+    });
+    expect(result?.lessons?.[0]._id).toBe('lesson-base');
+  });
+
+  it('merges practice questions/options without altering saved-answer keys', async () => {
+    mockFetch.mockResolvedValue([
+      {
+        _id: 'practice-base',
+        title: 'Practice',
+        questions: [
+          {
+            _key: 'question-1',
+            question_text: 'Base question',
+            options: [
+              { _key: 'option-a', text: 'Base A', value: 'a' },
+              { _key: 'option-b', text: 'Base B', value: 'b' },
+            ],
+          },
+        ],
+        i18n: {
+          _id: 'practice-es',
+          title: 'Práctica',
+          questions: [
+            {
+              _key: 'question-1',
+              question_text: 'Pregunta',
+              options: [{ _key: 'option-a', text: 'Opción A' }],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const [result] = await getPracticesBySubmodule('submodule-base', 'es');
+    expect(result._id).toBe('practice-base');
+    expect(result.questions?.[0]._key).toBe('question-1');
+    expect(result.questions?.[0].options).toEqual([
+      { _key: 'option-a', text: 'Opción A', value: 'a' },
+      { _key: 'option-b', text: 'Base B', value: 'b' },
+    ]);
+    expect(mockFetch.mock.calls[0][0]).toContain('language == "en"');
+  });
+
+  it('keeps quiz question and option identities stable', async () => {
+    mockFetch.mockResolvedValue([
+      {
+        _id: 'quiz-base',
+        questions: [
+          {
+            _key: 'question-1',
+            question_text: 'Base',
+            options: [{ _key: 'option-a', text: 'Base option' }],
+          },
+        ],
+        i18n: {
+          _id: 'quiz-hi',
+          questions: [
+            {
+              _key: 'question-1',
+              question_text: 'अनुवाद',
+              options: [{ _key: 'option-a', text: 'विकल्प' }],
+            },
+          ],
+        },
+      },
+    ]);
+
+    const [result] = await getLessonQuizzes('lesson-base', 'hi');
+    expect(result._id).toBe('quiz-base');
+    expect(result.questions[0]._key).toBe('question-1');
+    expect(result.questions[0].options?.[0]).toMatchObject({
+      _key: 'option-a',
+      text: 'विकल्प',
+    });
+  });
+
+  it('overlays task and checklist text while retaining persistence ids', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        _id: 'task-base',
+        title: 'Task',
+        content: [{ _key: 'block-1', text: 'Base' }],
+        i18n: {
+          _id: 'task-ar',
+          title: 'مهمة',
+          content: [{ _key: 'block-1', text: 'محتوى' }],
+        },
+      })
+      .mockResolvedValueOnce([
+        {
+          _id: 'checklist-base',
+          title: 'Checklist',
+          i18n: { _id: 'checklist-ar', title: 'قائمة' },
+        },
+      ]);
+
+    const task = await getTaskById('task-base', 'ar');
+    const [checklist] = await getChecklistByPersonaAndStage(
+      'skilled_worker',
+      'not_arrived',
+      { language: 'ar', skipCache: true }
+    );
+    expect(task).toMatchObject({
+      _id: 'task-base',
+      title: 'مهمة',
+      content: [{ _key: 'block-1', text: 'محتوى' }],
+    });
+    expect(checklist).toMatchObject({
+      _id: 'checklist-base',
+      title: 'قائمة',
+    });
+  });
+});

--- a/unify-front-end/__tests__/sanity/i18nOverlay.test.ts
+++ b/unify-front-end/__tests__/sanity/i18nOverlay.test.ts
@@ -1,0 +1,47 @@
+import {
+  mergeI18nOverlay,
+  normalizeSanityLanguage,
+} from '@/services/sanity/i18n';
+
+describe('Sanity language overlays', () => {
+  it('keeps the English document id while replacing translated content', () => {
+    type LessonStub = {
+      _id: string;
+      title: string;
+      description: string;
+    };
+    expect(
+      mergeI18nOverlay<LessonStub>({
+        _id: 'lesson-english-id',
+        title: 'English title',
+        description: 'English fallback',
+        i18n: {
+          _id: 'lesson-translated-id',
+          title: 'Titre français',
+          description: null,
+        },
+      })
+    ).toEqual({
+      _id: 'lesson-english-id',
+      title: 'Titre français',
+      description: 'English fallback',
+    });
+  });
+
+  it.each([
+    ['en', 'en'],
+    ['vi-VN', 'vi'],
+    ['es-MX', 'es'],
+    ['hi-IN', 'hi'],
+    ['ar-CA', 'ar'],
+    ['fr', 'fr-CA'],
+    ['fr-CA', 'fr-CA'],
+    ['pa-IN', 'en'],
+    ['unknown', 'en'],
+  ] as const)(
+    'normalizes %s to the available Sanity language %s',
+    (input, expected) => {
+      expect(normalizeSanityLanguage(input)).toBe(expected);
+    }
+  );
+});

--- a/unify-front-end/__tests__/sanity/i18nOverlay.test.ts
+++ b/unify-front-end/__tests__/sanity/i18nOverlay.test.ts
@@ -28,6 +28,76 @@ describe('Sanity language overlays', () => {
     });
   });
 
+  it('merges keyed rich content without changing progress identities or structure', () => {
+    const result = mergeI18nOverlay<any>({
+      _id: 'lesson-base',
+      pages: [
+        {
+          _key: 'page-1',
+          title: 'Base page',
+          questions: [
+            {
+              _key: 'question-1',
+              prompt: 'Base prompt',
+              options: [
+                { _key: 'option-a', text: 'Base A', is_correct: true },
+                { _key: 'option-b', text: 'Base B', is_correct: false },
+              ],
+            },
+          ],
+        },
+        { _key: 'page-2', title: 'Untouched page' },
+      ],
+      i18n: {
+        _id: 'lesson-translation',
+        pages: [
+          {
+            _key: 'page-1',
+            title: 'Página traducida',
+            questions: [
+              {
+                _key: 'question-1',
+                prompt: 'Pregunta traducida',
+                options: [
+                  { _key: 'option-a', text: 'Opción A' },
+                  { _key: 'option-extra', text: 'Must not alter structure' },
+                ],
+              },
+            ],
+          },
+          { _key: 'page-extra', title: 'Must not alter progress pages' },
+        ],
+      },
+    });
+
+    expect(result._id).toBe('lesson-base');
+    expect(result.pages.map((page: any) => page._key)).toEqual([
+      'page-1',
+      'page-2',
+    ]);
+    expect(result.pages[0].questions[0]._key).toBe('question-1');
+    expect(
+      result.pages[0].questions[0].options.map((option: any) => option._key)
+    ).toEqual(['option-a', 'option-b']);
+    expect(result.pages[0].title).toBe('Página traducida');
+    expect(result.pages[0].questions[0].prompt).toBe('Pregunta traducida');
+    expect(result.pages[0].questions[0].options).toEqual([
+      { _key: 'option-a', text: 'Opción A', is_correct: true },
+      { _key: 'option-b', text: 'Base B', is_correct: false },
+    ]);
+    expect(result.pages[1].title).toBe('Untouched page');
+  });
+
+  it('retains base rich content when a translation changes the field shape', () => {
+    expect(
+      mergeI18nOverlay<any>({
+        _id: 'lesson-base',
+        pages: [{ _key: 'page-1', title: 'Safe base page' }],
+        i18n: { pages: 'malformed translation payload' },
+      }).pages
+    ).toEqual([{ _key: 'page-1', title: 'Safe base page' }]);
+  });
+
   it.each([
     ['en', 'en'],
     ['vi-VN', 'vi'],

--- a/unify-front-end/__tests__/sanity/inProgressLanguageRace.test.ts
+++ b/unify-front-end/__tests__/sanity/inProgressLanguageRace.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+let mockLanguage = 'en';
+
+jest.mock('@/hooks/sanity/useSanityLanguage', () => ({
+  useSanityLanguage: () => mockLanguage,
+}));
+
+jest.mock('@/services/progress/progressClient', () => ({
+  progressClient: {
+    auth: {
+      getUser: jest
+        .fn()
+        .mockResolvedValue({ data: { user: { id: 'user-1' } } }),
+    },
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({
+        eq: jest.fn(() => ({
+          order: jest.fn().mockResolvedValue({ data: [], error: null }),
+        })),
+      })),
+    })),
+  },
+}));
+
+jest.mock('@/sanity-custom', () => ({
+  sanityClient: { fetch: jest.fn() },
+}));
+
+jest.mock('@/utils/progressEventEmitter', () => ({
+  progressEventEmitter: { subscribe: jest.fn(() => jest.fn()) },
+}));
+
+import { sanityClient } from '@/sanity-custom';
+import { useInProgressLessons } from '@/hooks/progress/useInProgressLessons';
+
+const mockFetch = sanityClient.fetch as jest.Mock;
+
+function content(title: string) {
+  return [
+    {
+      _id: 'module-1',
+      title: `${title} module`,
+      submodules: [
+        {
+          _id: 'submodule-1',
+          title: `${title} section`,
+          lessons: [
+            {
+              _id: 'lesson-1',
+              title,
+              lesson_page_count: 1,
+              activity_page_count: 0,
+              ending_page_count: 0,
+              quizzes: [],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+describe('Continue Learning language changes', () => {
+  beforeEach(() => {
+    mockLanguage = 'en';
+    mockFetch.mockReset();
+  });
+
+  it('ignores an old-language response that resolves after the new language', async () => {
+    let resolveEnglish!: (value: unknown) => void;
+    let resolveSpanish!: (value: unknown) => void;
+    mockFetch.mockImplementation((_query, params) => {
+      return new Promise(resolve => {
+        if (params.lang === 'en') resolveEnglish = resolve;
+        if (params.lang === 'es') resolveSpanish = resolve;
+      });
+    });
+
+    const { result, rerender } = renderHook(() => useInProgressLessons());
+    await waitFor(() => expect(resolveEnglish).toBeDefined());
+
+    mockLanguage = 'es';
+    rerender({});
+    await waitFor(() => expect(resolveSpanish).toBeDefined());
+
+    await act(async () => resolveSpanish(content('Lección')));
+    await waitFor(() =>
+      expect(result.current.lessons[0]?.title).toBe('Lección')
+    );
+
+    await act(async () => resolveEnglish(content('English lesson')));
+    expect(result.current.lessons[0]?.title).toBe('Lección');
+  });
+});

--- a/unify-front-end/__tests__/sanity/lessonService.test.ts
+++ b/unify-front-end/__tests__/sanity/lessonService.test.ts
@@ -1,0 +1,31 @@
+jest.mock('@/sanity-custom', () => ({
+  sanityClient: { fetch: jest.fn() },
+}));
+
+import { sanityClient } from '@/sanity-custom';
+import { getLesson } from '@/services/sanity/lessons';
+
+const mockFetchSanity = sanityClient.fetch as jest.Mock;
+
+describe('getLesson', () => {
+  beforeEach(() => mockFetchSanity.mockReset());
+
+  it('passes ids as SDK parameters and preserves the base id after translation', async () => {
+    mockFetchSanity.mockResolvedValue({
+      _id: 'english-lesson-id',
+      _type: 'lesson',
+      title: 'English',
+      i18n: { _id: 'translated-id', title: 'Español' },
+    });
+    const untrustedId = 'lesson-id"] | *[_type == "secret"';
+
+    await expect(getLesson(untrustedId, 'es')).resolves.toMatchObject({
+      _id: 'english-lesson-id',
+      title: 'Español',
+    });
+    const [query, params] = mockFetchSanity.mock.calls[0];
+    expect(query).toContain('_id == $lessonId');
+    expect(query).not.toContain(untrustedId);
+    expect(params).toEqual({ lessonId: untrustedId, lang: 'es' });
+  });
+});

--- a/unify-front-end/__tests__/sanity/queryKeys.test.ts
+++ b/unify-front-end/__tests__/sanity/queryKeys.test.ts
@@ -1,0 +1,22 @@
+import { sanityQueryKeys } from '@/hooks/sanity/sanityQueryKeys';
+import { checklistTasksQueryKey } from '@/hooks/checklist/checklistQueryKeys';
+import { buildChecklistCacheStorageKey } from '@/utils/checklistTaskCache';
+
+describe('language-aware content cache keys', () => {
+  it('separates Sanity lesson data by language', () => {
+    expect(sanityQueryKeys.lesson('lesson-1', 'en')).not.toEqual(
+      sanityQueryKeys.lesson('lesson-1', 'fr-CA')
+    );
+  });
+
+  it('separates checklist React Query and disk caches by language', () => {
+    expect(
+      checklistTasksQueryKey('user-1', 2, 'worker', false, 'en')
+    ).not.toEqual(checklistTasksQueryKey('user-1', 2, 'worker', false, 'ar'));
+    expect(
+      buildChecklistCacheStorageKey('user-1', 2, 'worker', false, 'en')
+    ).not.toEqual(
+      buildChecklistCacheStorageKey('user-1', 2, 'worker', false, 'ar')
+    );
+  });
+});

--- a/unify-front-end/__tests__/sanity/sanityClient.test.ts
+++ b/unify-front-end/__tests__/sanity/sanityClient.test.ts
@@ -1,0 +1,11 @@
+import { SANITY_CLIENT_CONFIG } from '@/sanity-config';
+
+describe('Sanity client', () => {
+  it('always reads published content and lets the SDK encode query params', () => {
+    expect(SANITY_CLIENT_CONFIG).toMatchObject({
+      apiVersion: '2024-01-01',
+      perspective: 'published',
+      useCdn: true,
+    });
+  });
+});

--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/quizzes/[quizId]/pages/[questionNum].tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/quizzes/[quizId]/pages/[questionNum].tsx
@@ -542,12 +542,11 @@ export default function QuizQuestionPage() {
         const correctAnswerId =
           currentQuestion.correct_answer?.value?.[0] ||
           currentQuestion.correct_answer?.value;
-        isAnswerCorrect = Boolean(
+        isAnswerCorrect =
           selectedAnswer === correctAnswerId ||
           currentQuestion.options?.find(
             (opt: any) => opt._key === selectedAnswer
-          )?.is_correct
-        );
+          )?.is_correct;
       }
 
       setIsCorrect(isAnswerCorrect);

--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/quizzes/[quizId]/pages/[questionNum].tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/quizzes/[quizId]/pages/[questionNum].tsx
@@ -542,11 +542,13 @@ export default function QuizQuestionPage() {
         const correctAnswerId =
           currentQuestion.correct_answer?.value?.[0] ||
           currentQuestion.correct_answer?.value;
-        isAnswerCorrect =
+        // `options` and a matching option are both optional in Sanity. Coerce
+        // the resulting boolean | undefined to the boolean UI state contract.
+        isAnswerCorrect = Boolean(
           selectedAnswer === correctAnswerId ||
-          currentQuestion.options?.find(
-            (opt: any) => opt._key === selectedAnswer
-          )?.is_correct;
+            currentQuestion.options?.find(opt => opt._key === selectedAnswer)
+              ?.is_correct
+        );
       }
 
       setIsCorrect(isAnswerCorrect);

--- a/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/quizzes/[quizId]/pages/[questionNum].tsx
+++ b/unify-front-end/app/(tabs)/Learn/modules/[moduleId]/[submoduleId]/lessons/[lessonId]/quizzes/[quizId]/pages/[questionNum].tsx
@@ -542,11 +542,12 @@ export default function QuizQuestionPage() {
         const correctAnswerId =
           currentQuestion.correct_answer?.value?.[0] ||
           currentQuestion.correct_answer?.value;
-        isAnswerCorrect =
+        isAnswerCorrect = Boolean(
           selectedAnswer === correctAnswerId ||
           currentQuestion.options?.find(
             (opt: any) => opt._key === selectedAnswer
-          )?.is_correct;
+          )?.is_correct
+        );
       }
 
       setIsCorrect(isAnswerCorrect);

--- a/unify-front-end/hooks/checklist/checklistQueryKeys.ts
+++ b/unify-front-end/hooks/checklist/checklistQueryKeys.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from '@tanstack/react-query';
+import type { SanityLanguage } from '@/services/sanity/i18n';
 
 /** Prefix for all checklist task list queries (persona + stage + user). */
 export const CHECKLIST_TASKS_QUERY_ROOT = 'checklist' as const;
@@ -7,7 +8,8 @@ export function checklistTasksQueryKey(
   userId: string,
   stage: number,
   personaSlug: string,
-  stageChanged: boolean
+  stageChanged: boolean,
+  language: SanityLanguage
 ) {
   return [
     CHECKLIST_TASKS_QUERY_ROOT,
@@ -15,6 +17,7 @@ export function checklistTasksQueryKey(
     stage,
     personaSlug,
     stageChanged,
+    language,
   ] as const;
 }
 

--- a/unify-front-end/hooks/checklist/useChecklistTasks.ts
+++ b/unify-front-end/hooks/checklist/useChecklistTasks.ts
@@ -21,6 +21,8 @@ import {
   stageNumberToStageSlug,
   normalizePersonaSlug,
 } from '@/helpers/dateHelpers';
+import { useSanityLanguage } from '@/hooks/sanity/useSanityLanguage';
+import type { SanityLanguage } from '@/services/sanity/i18n';
 
 interface UseChecklistTasksParams {
   currentStage: number | null;
@@ -32,14 +34,15 @@ async function fetchChecklistTasks(
   userId: string,
   currentStage: number,
   normalizedPersona: string,
-  stageChanged: boolean
+  stageChanged: boolean,
+  language: SanityLanguage
 ): Promise<UserTaskWithDetails[]> {
   const stageSlug = stageNumberToStageSlug(currentStage);
   const merged = await getChecklistWithUserProgress(
     userId,
     normalizedPersona,
     stageSlug,
-    { stageChanged }
+    { stageChanged, language }
   );
   try {
     const orders = await getChecklistTaskOrders(userId);
@@ -56,6 +59,7 @@ export const useChecklistTasks = ({
   persona,
 }: UseChecklistTasksParams) => {
   const queryClient = useQueryClient();
+  const language = useSanityLanguage();
   const [userId, setUserId] = useState<string | null>(null);
   const [cacheChecked, setCacheChecked] = useState(false);
 
@@ -89,9 +93,10 @@ export const useChecklistTasks = ({
       userId,
       currentStage,
       normalizedPersona,
-      stageChanged
+      stageChanged,
+      language
     );
-  }, [userId, currentStage, normalizedPersona, stageChanged]);
+  }, [userId, currentStage, normalizedPersona, stageChanged, language]);
 
   const storageKey = useMemo(() => {
     if (!queryKey) {
@@ -101,9 +106,17 @@ export const useChecklistTasks = ({
       userId!,
       currentStage!,
       normalizedPersona!,
-      stageChanged
+      stageChanged,
+      language
     );
-  }, [queryKey, userId, currentStage, normalizedPersona, stageChanged]);
+  }, [
+    queryKey,
+    userId,
+    currentStage,
+    normalizedPersona,
+    stageChanged,
+    language,
+  ]);
 
   // Hydrate React Query from memory (sync) then AsyncStorage before network fetch.
   useEffect(() => {
@@ -146,7 +159,8 @@ export const useChecklistTasks = ({
         userId!,
         currentStage!,
         normalizedPersona!,
-        stageChanged
+        stageChanged,
+        language
       ),
     enabled:
       cacheChecked &&
@@ -201,16 +215,17 @@ export const useChecklistTasks = ({
 
   const tasks = query.data ?? [];
 
-  const waitingForAuth =
-    Boolean(persona && currentStage !== null && userId === null);
+  const waitingForAuth = Boolean(
+    persona && currentStage !== null && userId === null
+  );
 
   const isLoading =
     waitingForAuth ||
     Boolean(
       queryKey &&
-        normalizedPersona &&
-        currentStage !== null &&
-        (!cacheChecked || (query.isPending && query.data === undefined))
+      normalizedPersona &&
+      currentStage !== null &&
+      (!cacheChecked || (query.isPending && query.data === undefined))
     );
 
   return {

--- a/unify-front-end/hooks/checklist/useChecklistTasks.ts
+++ b/unify-front-end/hooks/checklist/useChecklistTasks.ts
@@ -168,7 +168,10 @@ export const useChecklistTasks = ({
       !!userId &&
       currentStage !== null &&
       !!normalizedPersona,
-    staleTime: Infinity,
+    // Hydrated cache renders immediately, then revalidates for newly published
+    // Sanity translations. Disk/memory entries separately expire after 10 min.
+    staleTime: 0,
+    refetchOnMount: true,
     gcTime: 1000 * 60 * 60 * 24 * 7,
   });
 

--- a/unify-front-end/hooks/learn/usePersonalizedModules.ts
+++ b/unify-front-end/hooks/learn/usePersonalizedModules.ts
@@ -146,7 +146,6 @@ export function usePersonalizedModules(): UsePersonalizedModulesResult {
     queryFn: () => getAllModulesWithSubmodules(language),
     staleTime: 15 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
-    placeholderData: keepPreviousData,
   });
 
   // Always fetch personalized ranking

--- a/unify-front-end/hooks/learn/usePersonalizedModules.ts
+++ b/unify-front-end/hooks/learn/usePersonalizedModules.ts
@@ -9,6 +9,8 @@ import type {
   PersonalizedModule,
 } from '@/types/learn';
 import type { SanityModuleWithSubmodules } from '@/types/sanity';
+import { sanityQueryKeys } from '@/hooks/sanity/sanityQueryKeys';
+import { useSanityLanguage } from '@/hooks/sanity/useSanityLanguage';
 
 // ─── Personalize fetch ────────────────────────────────────────────────────────
 
@@ -48,7 +50,9 @@ async function fetchPersonalizedLearn(): Promise<PersonalizeLearnResponse | null
 
 // ─── Independent progress fetch (used in fallback path) ─────────────────────
 
-async function fetchAllModuleProgress(): Promise<Map<string, ModuleProgressStatus>> {
+async function fetchAllModuleProgress(): Promise<
+  Map<string, ModuleProgressStatus>
+> {
   const {
     data: { session },
   } = await supabase.auth.getSession();
@@ -102,7 +106,12 @@ function mergePersonalizedWithSanity(
 
   // Append unscored Sanity modules at the end
   for (const remaining of sanityById.values()) {
-    result.push({ ...remaining, progress: 'not_started', score: 0, why_tag: '' });
+    result.push({
+      ...remaining,
+      progress: 'not_started',
+      score: 0,
+      why_tag: '',
+    });
   }
 
   return result;
@@ -125,6 +134,7 @@ interface UsePersonalizedModulesResult {
 }
 
 export function usePersonalizedModules(): UsePersonalizedModulesResult {
+  const language = useSanityLanguage();
   // Always fetch Sanity modules (they own colorTheme, icon, submodules)
   const {
     data: sanityModules,
@@ -132,8 +142,8 @@ export function usePersonalizedModules(): UsePersonalizedModulesResult {
     error: sanityError,
     refetch: refetchSanity,
   } = useQuery({
-    queryKey: ['sanity', 'modules'],
-    queryFn: getAllModulesWithSubmodules,
+    queryKey: sanityQueryKeys.modules(language),
+    queryFn: () => getAllModulesWithSubmodules(language),
     staleTime: 15 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
     placeholderData: keepPreviousData,

--- a/unify-front-end/hooks/progress/useInProgressLessons.ts
+++ b/unify-front-end/hooks/progress/useInProgressLessons.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { progressClient } from '@/services/progress/progressClient';
 import { sanityClient } from '@/sanity-custom';
 import { progressEventEmitter } from '@/utils/progressEventEmitter';
@@ -41,8 +41,11 @@ export function useInProgressLessons() {
   const [lessons, setLessons] = useState<ContinueLesson[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const requestSequence = useRef(0);
 
-  const fetchInProgressLessons = async () => {
+  const fetchInProgressLessons = useCallback(async () => {
+    const requestId = ++requestSequence.current;
+    const isLatestRequest = () => requestId === requestSequence.current;
     try {
       setIsLoading(true);
       setError(null);
@@ -52,8 +55,7 @@ export function useInProgressLessons() {
         data: { user },
       } = await progressClient.auth.getUser();
       if (!user) {
-        setLessons([]);
-        setIsLoading(false);
+        if (isLatestRequest()) setLessons([]);
         return;
       }
 
@@ -68,9 +70,10 @@ export function useInProgressLessons() {
           .order('last_accessed_at', { ascending: false });
 
       if (lessonError) {
-        console.error('Error fetching lesson progress:', lessonError);
-        setError('Failed to fetch lessons');
-        setIsLoading(false);
+        if (isLatestRequest()) {
+          console.error('Error fetching lesson progress:', lessonError);
+          setError('Failed to fetch lessons');
+        }
         return;
       }
 
@@ -193,29 +196,34 @@ export function useInProgressLessons() {
         return new Date(bAccess).getTime() - new Date(aAccess).getTime();
       });
 
-      setLessons(inProgressLessons);
+      if (isLatestRequest()) setLessons(inProgressLessons);
     } catch (error) {
-      console.error('Error fetching in-progress lessons:', error);
-      setError('Failed to load lessons');
+      if (isLatestRequest()) {
+        console.error('Error fetching in-progress lessons:', error);
+        setError('Failed to load lessons');
+      }
     } finally {
-      setIsLoading(false);
+      if (isLatestRequest()) setIsLoading(false);
     }
-  };
+  }, [language]);
 
   // Fetch on mount and whenever the content language changes.
   useEffect(() => {
-    fetchInProgressLessons();
-  }, [language]);
+    void fetchInProgressLessons();
+    return () => {
+      requestSequence.current += 1;
+    };
+  }, [fetchInProgressLessons]);
 
   // Subscribe to progress update events
   useEffect(() => {
     const unsubscribe = progressEventEmitter.subscribe(() => {
       // Only refetch when progress is logged to the database
-      fetchInProgressLessons();
+      void fetchInProgressLessons();
     });
 
     return unsubscribe;
-  }, [language]);
+  }, [fetchInProgressLessons]);
 
   return {
     lessons,

--- a/unify-front-end/hooks/progress/useInProgressLessons.ts
+++ b/unify-front-end/hooks/progress/useInProgressLessons.ts
@@ -1,8 +1,14 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { progressClient } from '@/services/progress/progressClient';
 import { sanityClient } from '@/sanity-custom';
 import { progressEventEmitter } from '@/utils/progressEventEmitter';
 import { getLessonTotalPages } from '@/utils/submoduleProgress';
+import { useSanityLanguage } from '@/hooks/sanity/useSanityLanguage';
+import {
+  BASE_LANGUAGE_FILTER,
+  i18nOverlay,
+  mergeI18nOverlay,
+} from '@/services/sanity/i18n';
 
 interface ContinueLesson {
   id: string;
@@ -31,6 +37,7 @@ interface LessonProgressRow {
 }
 
 export function useInProgressLessons() {
+  const language = useSanityLanguage();
   const [lessons, setLessons] = useState<ContinueLesson[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -68,14 +75,16 @@ export function useInProgressLessons() {
       }
 
       // Fetch modules/submodules/lessons with compact page counts from Sanity
-      const modulesQuery = `*[_type == "module"] {
+      const modulesQuery = `*[_type == "module" && ${BASE_LANGUAGE_FILTER}] {
           _id,
           title,
-          "submodules": *[_type == "submodule" && references(^._id)] | order(order) {
+          ${i18nOverlay('title')},
+          "submodules": *[_type == "submodule" && references(^._id) && ${BASE_LANGUAGE_FILTER}] | order(order) {
             _id,
             title,
             order,
-            "lessons": *[_type == "lesson" && references(^._id)] | order(order) {
+            ${i18nOverlay('title')},
+            "lessons": *[_type == "lesson" && references(^._id) && ${BASE_LANGUAGE_FILTER}] | order(order) {
               _id,
               title,
               description,
@@ -83,7 +92,8 @@ export function useInProgressLessons() {
               "lesson_page_count": count(pages),
               "activity_page_count": count(activity_pages),
               "ending_page_count": count(ending_pages),
-              "quizzes": *[_type == "quiz" && references(^._id)] | order(order_number) {
+              ${i18nOverlay('title, description')},
+              "quizzes": *[_type == "quiz" && references(^._id) && ${BASE_LANGUAGE_FILTER}] | order(order_number) {
                 _id,
                 "question_count": count(questions)
               }
@@ -91,7 +101,18 @@ export function useInProgressLessons() {
           }
         }`;
 
-      const modulesData = await sanityClient.fetch(modulesQuery);
+      const rawModules = await sanityClient.fetch(modulesQuery, {
+        lang: language,
+      });
+      const modulesData = (rawModules ?? []).map((module: any) => ({
+        ...mergeI18nOverlay(module),
+        submodules: (module.submodules ?? []).map((submodule: any) => ({
+          ...mergeI18nOverlay(submodule),
+          lessons: (submodule.lessons ?? []).map((lesson: any) =>
+            mergeI18nOverlay(lesson)
+          ),
+        })),
+      }));
 
       const progressRows = (lessonProgresses || []) as LessonProgressRow[];
 
@@ -181,16 +202,10 @@ export function useInProgressLessons() {
     }
   };
 
-  // Track if this is the first mount
-  const isFirstMount = useRef(true);
-
-  // Fetch on mount (first time only)
+  // Fetch on mount and whenever the content language changes.
   useEffect(() => {
-    if (isFirstMount.current) {
-      fetchInProgressLessons();
-      isFirstMount.current = false;
-    }
-  }, []);
+    fetchInProgressLessons();
+  }, [language]);
 
   // Subscribe to progress update events
   useEffect(() => {
@@ -200,7 +215,7 @@ export function useInProgressLessons() {
     });
 
     return unsubscribe;
-  }, []);
+  }, [language]);
 
   return {
     lessons,

--- a/unify-front-end/hooks/sanity/sanityQueryKeys.ts
+++ b/unify-front-end/hooks/sanity/sanityQueryKeys.ts
@@ -1,0 +1,26 @@
+import type { SanityLanguage } from '@/services/sanity/i18n';
+
+export const sanityQueryKeys = {
+  modules: (language: SanityLanguage) =>
+    ['sanity', 'modules', language] as const,
+  module: (moduleId: string, language: SanityLanguage) =>
+    ['sanity', 'module', moduleId, language] as const,
+  moduleWithSubmodules: (moduleId: string, language: SanityLanguage) =>
+    ['sanity', 'moduleWithSubmodules', moduleId, language] as const,
+  submoduleWithLessons: (submoduleId: string, language: SanityLanguage) =>
+    ['sanity', 'submoduleWithLessons', submoduleId, language] as const,
+  lesson: (lessonId: string, language: SanityLanguage) =>
+    ['sanity', 'lesson', lessonId, language] as const,
+  practices: (submoduleId: string, language: SanityLanguage) =>
+    ['sanity', 'practices', submoduleId, language] as const,
+  practice: (practiceId: string, language: SanityLanguage) =>
+    ['sanity', 'practice', practiceId, language] as const,
+  lessonQuizzes: (lessonId: string, language: SanityLanguage) =>
+    ['sanity', 'lessonQuizzes', lessonId, language] as const,
+  quizQuestions: (quizId: string, language: SanityLanguage) =>
+    ['sanity', 'quizQuestions', quizId, language] as const,
+  tasks: (submoduleId: string, language: SanityLanguage) =>
+    ['sanity', 'tasks', submoduleId, language] as const,
+  task: (taskId: string, language: SanityLanguage) =>
+    ['sanity', 'task', taskId, language] as const,
+};

--- a/unify-front-end/hooks/sanity/useSanityLanguage.ts
+++ b/unify-front-end/hooks/sanity/useSanityLanguage.ts
@@ -1,0 +1,8 @@
+import { useTranslation } from 'react-i18next';
+import { normalizeSanityLanguage } from '@/services/sanity/i18n';
+
+/** The content locale used by Sanity fetches and cache keys. */
+export function useSanityLanguage() {
+  const { i18n } = useTranslation();
+  return normalizeSanityLanguage(i18n.resolvedLanguage ?? i18n.language);
+}

--- a/unify-front-end/hooks/sanity/useSanityLessons.ts
+++ b/unify-front-end/hooks/sanity/useSanityLessons.ts
@@ -1,10 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { getLesson } from '../../services/sanity/lessons';
+import { sanityQueryKeys } from './sanityQueryKeys';
+import { useSanityLanguage } from './useSanityLanguage';
 
 export function useSanityLesson(lessonId: string) {
+  const language = useSanityLanguage();
   return useQuery({
-    queryKey: ['sanity', 'lesson', lessonId],
-    queryFn: () => getLesson(lessonId),
+    queryKey: sanityQueryKeys.lesson(lessonId, language),
+    queryFn: () => getLesson(lessonId, language),
     enabled: !!lessonId,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/unify-front-end/hooks/sanity/useSanityModules.ts
+++ b/unify-front-end/hooks/sanity/useSanityModules.ts
@@ -5,20 +5,24 @@ import {
   getModule,
   getModuleWithSubmodules,
 } from '../../services/sanity/modules';
+import { sanityQueryKeys } from './sanityQueryKeys';
+import { useSanityLanguage } from './useSanityLanguage';
 
 export function useSanityModules() {
+  const language = useSanityLanguage();
   return useQuery({
-    queryKey: ['sanity', 'modules'],
-    queryFn: getAllModulesWithSubmodules,
+    queryKey: sanityQueryKeys.modules(language),
+    queryFn: () => getAllModulesWithSubmodules(language),
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes
   });
 }
 
 export function useSanityModule(moduleId: string) {
+  const language = useSanityLanguage();
   return useQuery({
-    queryKey: ['sanity', 'module', moduleId],
-    queryFn: () => getModule(moduleId),
+    queryKey: sanityQueryKeys.module(moduleId, language),
+    queryFn: () => getModule(moduleId, language),
     enabled: !!moduleId,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
@@ -26,9 +30,10 @@ export function useSanityModule(moduleId: string) {
 }
 
 export function useSanityModuleWithSubmodules(moduleId: string) {
+  const language = useSanityLanguage();
   return useQuery({
-    queryKey: ['sanity', 'moduleWithSubmodules', moduleId],
-    queryFn: () => getModuleWithSubmodules(moduleId),
+    queryKey: sanityQueryKeys.moduleWithSubmodules(moduleId, language),
+    queryFn: () => getModuleWithSubmodules(moduleId, language),
     enabled: !!moduleId,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/unify-front-end/hooks/sanity/useSanityPractices.ts
+++ b/unify-front-end/hooks/sanity/useSanityPractices.ts
@@ -3,11 +3,14 @@ import {
   getPracticesBySubmodule,
   getPracticeById,
 } from '@/services/sanity/practices';
+import { sanityQueryKeys } from './sanityQueryKeys';
+import { useSanityLanguage } from './useSanityLanguage';
 
 export function useSanityPractices(submoduleId: string) {
+  const language = useSanityLanguage();
   return useQuery({
-    queryKey: ['sanity', 'practices', submoduleId],
-    queryFn: () => getPracticesBySubmodule(submoduleId),
+    queryKey: sanityQueryKeys.practices(submoduleId, language),
+    queryFn: () => getPracticesBySubmodule(submoduleId, language),
     enabled: !!submoduleId,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
@@ -15,9 +18,10 @@ export function useSanityPractices(submoduleId: string) {
 }
 
 export function useSanityPractice(practiceId: string) {
+  const language = useSanityLanguage();
   return useQuery({
-    queryKey: ['sanity', 'practice', practiceId],
-    queryFn: () => getPracticeById(practiceId),
+    queryKey: sanityQueryKeys.practice(practiceId, language),
+    queryFn: () => getPracticeById(practiceId, language),
     enabled: !!practiceId,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/unify-front-end/hooks/sanity/useSanityQuizzes.ts
+++ b/unify-front-end/hooks/sanity/useSanityQuizzes.ts
@@ -3,11 +3,14 @@ import {
   getLessonQuizzes,
   getQuizQuestions,
 } from '../../services/sanity/quizzes';
+import { sanityQueryKeys } from './sanityQueryKeys';
+import { useSanityLanguage } from './useSanityLanguage';
 
 export function useSanityLessonQuizzes(lessonId: string) {
+  const language = useSanityLanguage();
   return useQuery({
-    queryKey: ['sanity', 'lessonQuizzes', lessonId],
-    queryFn: () => getLessonQuizzes(lessonId),
+    queryKey: sanityQueryKeys.lessonQuizzes(lessonId, language),
+    queryFn: () => getLessonQuizzes(lessonId, language),
     enabled: !!lessonId,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
@@ -15,9 +18,10 @@ export function useSanityLessonQuizzes(lessonId: string) {
 }
 
 export function useSanityQuizQuestions(quizId: string) {
+  const language = useSanityLanguage();
   return useQuery({
-    queryKey: ['sanity', 'quizQuestions', quizId],
-    queryFn: () => getQuizQuestions(quizId),
+    queryKey: sanityQueryKeys.quizQuestions(quizId, language),
+    queryFn: () => getQuizQuestions(quizId, language),
     enabled: !!quizId,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/unify-front-end/hooks/sanity/useSanitySubmodules.ts
+++ b/unify-front-end/hooks/sanity/useSanitySubmodules.ts
@@ -1,10 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { getSubmoduleWithLessons } from '../../services/sanity/submodules';
+import { sanityQueryKeys } from './sanityQueryKeys';
+import { useSanityLanguage } from './useSanityLanguage';
 
 export function useSanitySubmoduleWithLessons(submoduleId: string) {
+  const language = useSanityLanguage();
   return useQuery({
-    queryKey: ['sanity', 'submoduleWithLessons', submoduleId],
-    queryFn: () => getSubmoduleWithLessons(submoduleId),
+    queryKey: sanityQueryKeys.submoduleWithLessons(submoduleId, language),
+    queryFn: () => getSubmoduleWithLessons(submoduleId, language),
     enabled: !!submoduleId,
     staleTime: 30 * 60 * 1000, // 30 minutes - lesson structure rarely changes
     gcTime: 60 * 60 * 1000, // 1 hour

--- a/unify-front-end/hooks/sanity/useSanityTasks.ts
+++ b/unify-front-end/hooks/sanity/useSanityTasks.ts
@@ -1,10 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { getTasksBySubmodule, getTaskById } from '@/services/sanity/tasks';
+import { sanityQueryKeys } from './sanityQueryKeys';
+import { useSanityLanguage } from './useSanityLanguage';
 
 export function useSanityTasks(submoduleId: string) {
+  const language = useSanityLanguage();
   return useQuery({
-    queryKey: ['sanity', 'tasks', submoduleId],
-    queryFn: () => getTasksBySubmodule(submoduleId),
+    queryKey: sanityQueryKeys.tasks(submoduleId, language),
+    queryFn: () => getTasksBySubmodule(submoduleId, language),
     enabled: !!submoduleId,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
@@ -12,9 +15,10 @@ export function useSanityTasks(submoduleId: string) {
 }
 
 export function useSanityTask(taskId: string) {
+  const language = useSanityLanguage();
   return useQuery({
-    queryKey: ['sanity', 'task', taskId],
-    queryFn: () => getTaskById(taskId),
+    queryKey: sanityQueryKeys.task(taskId, language),
+    queryFn: () => getTaskById(taskId, language),
     enabled: !!taskId,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/unify-front-end/package-lock.json
+++ b/unify-front-end/package-lock.json
@@ -14,6 +14,7 @@
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-google-signin/google-signin": "^16.1.2",
         "@react-navigation/native": "^7.0.0",
+        "@sanity/client": "7.22.0",
         "@supabase/supabase-js": "^2.50.4",
         "@tanstack/react-query": "^5.83.0",
         "dayjs": "^1.11.19",
@@ -8106,6 +8107,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sanity/client": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.0.tgz",
+      "integrity": "sha512-KqN9cowZwfZNCwCchRaz1B9WrZTThQxX/gfJhJO1uKJBuk/JcbYGBiSK9CSqocWoYDQ/QqANVXy1r7a8zognww==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.7.2",
+        "nanoid": "^3.3.11",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@sanity/eventsource": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.4.tgz",
+      "integrity": "sha512-NT6XrTJePJd7q1ZdTqB3NsTyNNOe9R2zMkg4Hlkqwb0LL6UmekVamAD46yjSJ+HbRyXAKLl1Rb65xZBdzC1f8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/event-source-polyfill": "1.0.5",
+        "@types/eventsource": "1.1.15",
+        "event-source-polyfill": "1.0.31",
+        "eventsource": "2.0.2"
+      }
+    },
+    "node_modules/@sanity/eventsource/node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -10213,6 +10250,18 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/event-source-polyfill": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz",
+      "integrity": "sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/eventsource": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
+      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==",
       "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
@@ -15183,6 +15232,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
+      "license": "MIT"
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -17096,6 +17151,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-it": {
+      "version": "8.8.3",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.8.3.tgz",
+      "integrity": "sha512-IfkbWqOGO2kd2Ccgiz/NIzk3bcwjtVqBm3RNa3j/veHg2q7c1DgS3EXrCrvIWH0jbNTbhkdblnxBP7Dm8CiH+A==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^7.0.0",
+        "is-retry-allowed": "^2.2.0",
+        "through2": "^4.0.2",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/get-it/node_modules/decompress-response": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-7.0.0.tgz",
+      "integrity": "sha512-6IvPrADQyyPGLpMnUh6kfKiqy7SrbXbjoUuZ90WMBJKErzv2pCiwlGEXjRX9/54OnTq+XFVnkOnOMzclLI5aEA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -18616,6 +18701,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {
@@ -21499,7 +21596,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -26081,7 +26177,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -26545,7 +26640,6 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -27599,7 +27693,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -28206,6 +28299,15 @@
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT"
     },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      }
+    },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
@@ -28467,7 +28569,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -28985,7 +29086,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {

--- a/unify-front-end/package.json
+++ b/unify-front-end/package.json
@@ -44,6 +44,7 @@
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-google-signin/google-signin": "^16.1.2",
     "@react-navigation/native": "^7.0.0",
+    "@sanity/client": "7.22.0",
     "@supabase/supabase-js": "^2.50.4",
     "@tanstack/react-query": "^5.83.0",
     "dayjs": "^1.11.19",

--- a/unify-front-end/sanity-config.ts
+++ b/unify-front-end/sanity-config.ts
@@ -1,0 +1,19 @@
+const projectId =
+  process.env.EXPO_PUBLIC_SANITY_PROJECT_ID ||
+  process.env.SANITY_PROJECT_ID ||
+  'placeholder';
+const dataset =
+  process.env.EXPO_PUBLIC_SANITY_DATASET ||
+  process.env.SANITY_DATASET ||
+  'production';
+
+export const SANITY_CLIENT_CONFIG = {
+  projectId,
+  dataset,
+  apiVersion: '2024-01-01',
+  useCdn: true,
+  perspective: 'published' as const,
+};
+
+export const SANITY_PROJECT_ID = projectId;
+export const SANITY_DATASET = dataset;

--- a/unify-front-end/sanity-custom.ts
+++ b/unify-front-end/sanity-custom.ts
@@ -1,64 +1,15 @@
-const projectId =
-  process.env.EXPO_PUBLIC_SANITY_PROJECT_ID || process.env.SANITY_PROJECT_ID;
-const dataset =
-  process.env.EXPO_PUBLIC_SANITY_DATASET ||
-  process.env.SANITY_DATASET ||
-  'production';
-const apiVersion = '2023-05-03';
+import { createClient } from '@sanity/client';
+import {
+  SANITY_CLIENT_CONFIG,
+  SANITY_DATASET,
+  SANITY_PROJECT_ID,
+} from './sanity-config';
 
-// Custom Sanity client using direct HTTP requests
-export const sanityClient = {
-  fetch: async (query: string, params: any = {}) => {
-    try {
-      const baseUrl = `https://${projectId}.api.sanity.io/v${apiVersion}/data/query/${dataset}`;
-      const url = new URL(baseUrl);
-      url.searchParams.set('query', query);
+export { SANITY_CLIENT_CONFIG } from './sanity-config';
 
-      // Sanity API doesn't support params query parameter
-      // We need to replace the parameters in the query string directly
-      let processedQuery = query;
-      if (Object.keys(params).length > 0) {
-        Object.keys(params).forEach(key => {
-          const value = params[key];
-          if (typeof value === 'string') {
-            processedQuery = processedQuery.replace(
-              new RegExp(`\\$${key}`, 'g'),
-              `"${value}"`
-            );
-          } else {
-            processedQuery = processedQuery.replace(
-              new RegExp(`\\$${key}`, 'g'),
-              JSON.stringify(value)
-            );
-          }
-        });
-      }
-      url.searchParams.set('query', processedQuery);
+/** The SDK serializes GROQ parameters separately instead of interpolating them. */
+export const sanityClient = createClient(SANITY_CLIENT_CONFIG);
 
-      const response = await fetch(url.toString(), {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error(
-          `Sanity API error: ${response.status} ${response.statusText}`
-        );
-      }
-
-      const data = await response.json();
-      return data.result || [];
-    } catch (error) {
-      console.error('Sanity fetch error:', error);
-      throw error;
-    }
-  },
-};
-
-// Helper function to get image URL
-// Helper function to get image URL
 export const urlFor = (source: any) => {
   if (source && source.asset && source.asset._ref) {
     const imageId = source.asset._ref
@@ -66,7 +17,7 @@ export const urlFor = (source: any) => {
       .replace('-jpg', '.jpg')
       .replace('-png', '.png')
       .replace('-webp', '.webp');
-    return `https://cdn.sanity.io/images/${projectId}/${dataset}/${imageId}`;
+    return `https://cdn.sanity.io/images/${SANITY_PROJECT_ID}/${SANITY_DATASET}/${imageId}`;
   }
   return '';
 };

--- a/unify-front-end/services/checklist/getChecklistWithUserProgress.ts
+++ b/unify-front-end/services/checklist/getChecklistWithUserProgress.ts
@@ -5,11 +5,15 @@ import {
   UserTaskWithDetails,
   sanityChecklistItemToTaskDetails,
 } from '@/types/checklist';
-import { CHECKLIST_PRIORITY_ORDER, normalizeChecklistPriority } from '@/utils/checklistOrder';
+import {
+  CHECKLIST_PRIORITY_ORDER,
+  normalizeChecklistPriority,
+} from '@/utils/checklistOrder';
 import { getChecklistByPersonaAndStage } from '@/services/sanity/checklist';
 import { getUserTasks } from './getUserTasks';
 import { deleteUserTasks } from './deleteUserTasks';
 import { getCustomChecklistTasks } from './customChecklistTasks';
+import type { SanityLanguage } from '@/services/sanity/i18n';
 
 function mergeChecklistWithUserTasks(
   items: SanityChecklistItem[],
@@ -67,7 +71,7 @@ export async function getChecklistWithUserProgress(
   userId: string,
   persona: string,
   stageSlug: string,
-  options: { stageChanged?: boolean }
+  options: { stageChanged?: boolean; language?: SanityLanguage }
 ): Promise<UserTaskWithDetails[]> {
   if (options.stageChanged) {
     await deleteUserTasks(userId);
@@ -75,6 +79,7 @@ export async function getChecklistWithUserProgress(
 
   const items = await getChecklistByPersonaAndStage(persona, stageSlug, {
     skipCache: true,
+    language: options.language,
   });
 
   const rows = items.length > 0 ? await getUserTasks(userId) : [];
@@ -85,12 +90,12 @@ export async function getChecklistWithUserProgress(
 
   // Interleave custom tasks into correct priority positions
   const allTasks = [...sanityTasks, ...customTasks];
-  const priorityIndex = new Map(
-    CHECKLIST_PRIORITY_ORDER.map((p, i) => [p, i])
-  );
+  const priorityIndex = new Map(CHECKLIST_PRIORITY_ORDER.map((p, i) => [p, i]));
   allTasks.sort((a, b) => {
-    const aIdx = priorityIndex.get(normalizeChecklistPriority(a.task.priority)) ?? 99;
-    const bIdx = priorityIndex.get(normalizeChecklistPriority(b.task.priority)) ?? 99;
+    const aIdx =
+      priorityIndex.get(normalizeChecklistPriority(a.task.priority)) ?? 99;
+    const bIdx =
+      priorityIndex.get(normalizeChecklistPriority(b.task.priority)) ?? 99;
     return aIdx - bIdx;
   });
 

--- a/unify-front-end/services/learn/moduleProgressService.ts
+++ b/unify-front-end/services/learn/moduleProgressService.ts
@@ -108,9 +108,9 @@ export async function maybeMarkModuleCompleted(
 
     // Fetch every lesson _id under this module via Sanity. `references()` walks
     // the module → submodule → lesson graph implicitly by nesting.
-    const query = `*[_type == "module" && _id == $moduleId][0] {
-      "lessonIds": *[_type == "submodule" && references(^._id)][] {
-        "ids": *[_type == "lesson" && references(^._id)]._id
+    const query = `*[_type == "module" && _id == $moduleId && (language == "en" || !defined(language))][0] {
+      "lessonIds": *[_type == "submodule" && references(^._id) && (language == "en" || !defined(language))][] {
+        "ids": *[_type == "lesson" && references(^._id) && (language == "en" || !defined(language))]._id
       }.ids[]
     }`;
     const result = await sanityClient.fetch(query, { moduleId });
@@ -143,6 +143,9 @@ export async function maybeMarkModuleCompleted(
       await upsertModuleProgress(moduleId, 'completed');
     }
   } catch (err) {
-    console.error('[moduleProgressService] maybeMarkModuleCompleted error', err);
+    console.error(
+      '[moduleProgressService] maybeMarkModuleCompleted error',
+      err
+    );
   }
 }

--- a/unify-front-end/services/progress/cachedProgressService.ts
+++ b/unify-front-end/services/progress/cachedProgressService.ts
@@ -113,11 +113,11 @@ class CachedProgressService {
       // Fetch all modules with submodules and lessons from Sanity
       let modulesData = null;
       try {
-        const sanityQuery = `*[_type == "module"] {
+        const sanityQuery = `*[_type == "module" && (language == "en" || !defined(language))] {
           _id,
-          "submodules": *[_type == "submodule" && references(^._id)] | order(order) {
+          "submodules": *[_type == "submodule" && references(^._id) && (language == "en" || !defined(language))] | order(order) {
             _id,
-            "lessons": *[_type == "lesson" && references(^._id)] | order(order) {
+            "lessons": *[_type == "lesson" && references(^._id) && (language == "en" || !defined(language))] | order(order) {
               _id
             }
           }

--- a/unify-front-end/services/sanity/checklist.ts
+++ b/unify-front-end/services/sanity/checklist.ts
@@ -1,5 +1,11 @@
 import { sanityClient } from '../../sanity-custom';
 import { SanityChecklistItem } from '@/types/checklist';
+import {
+  i18nOverlay,
+  mergeI18nOverlay,
+  type SanityLanguage,
+  type WithI18n,
+} from './i18n';
 
 /**
  * GROQ: checklist items where user's persona is in item's personas array
@@ -8,6 +14,7 @@ import { SanityChecklistItem } from '@/types/checklist';
  */
 const CHECKLIST_QUERY = `*[
   _type == "checklist"
+  && (language == "en" || !defined(language))
   && $persona in personas
   && stage == $stage
 ] | order(class asc, class_order asc) {
@@ -19,12 +26,16 @@ const CHECKLIST_QUERY = `*[
   class,
   class_order,
   link_tab,
+  ${i18nOverlay('title, description, longer_description')},
   "module": module-> { _id, title },
   "submodule": submodule-> { _id, title, "moduleId": module._ref }
 }`;
 
-const CACHE_KEY = (persona: string, stageSlug: string) =>
-  `checklist:${persona}:${stageSlug}`;
+const CACHE_KEY = (
+  persona: string,
+  stageSlug: string,
+  language: SanityLanguage
+) => `checklist:${persona}:${stageSlug}:${language}`;
 const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 let cache: {
@@ -36,9 +47,10 @@ let cache: {
 export async function getChecklistByPersonaAndStage(
   persona: string,
   stageSlug: string,
-  options?: { skipCache?: boolean }
+  options?: { skipCache?: boolean; language?: SanityLanguage }
 ): Promise<SanityChecklistItem[]> {
-  const key = CACHE_KEY(persona, stageSlug);
+  const language = options?.language ?? 'en';
+  const key = CACHE_KEY(persona, stageSlug, language);
   const now = Date.now();
 
   if (
@@ -50,11 +62,15 @@ export async function getChecklistByPersonaAndStage(
   }
 
   try {
-    const result = await sanityClient.fetch(CHECKLIST_QUERY, {
-      persona,
-      stage: stageSlug,
-    });
-    const data = Array.isArray(result) ? result : [];
+    const result = await sanityClient.fetch<WithI18n<SanityChecklistItem>[]>(
+      CHECKLIST_QUERY,
+      {
+        persona,
+        stage: stageSlug,
+        lang: language,
+      }
+    );
+    const data = Array.isArray(result) ? result.map(mergeI18nOverlay) : [];
     cache = { key, data, ts: now };
     return data;
   } catch (error) {

--- a/unify-front-end/services/sanity/checklist.ts
+++ b/unify-front-end/services/sanity/checklist.ts
@@ -75,8 +75,10 @@ export async function getChecklistByPersonaAndStage(
     return data;
   } catch (error) {
     console.error('Error fetching checklist from Sanity:', error);
-    if (cache?.key === key) return cache.data;
-    return [];
+    if (!options?.skipCache && cache?.key === key) return cache.data;
+    // A transport/query failure is not a legitimate empty checklist. Reject so
+    // React Query retains hydrated same-language data and does not persist `[]`.
+    throw error;
   }
 }
 

--- a/unify-front-end/services/sanity/i18n.ts
+++ b/unify-front-end/services/sanity/i18n.ts
@@ -1,0 +1,52 @@
+export const SANITY_LANGUAGES = [
+  'en',
+  'vi',
+  'es',
+  'hi',
+  'ar',
+  'fr-CA',
+] as const;
+
+export type SanityLanguage = (typeof SANITY_LANGUAGES)[number];
+
+/** Resolve regional UI locales to available Sanity translation keys. */
+export function normalizeSanityLanguage(
+  language: string | null | undefined
+): SanityLanguage {
+  const normalized = language?.trim().toLowerCase();
+  if (!normalized) return 'en';
+  if (normalized === 'fr' || normalized.startsWith('fr-')) return 'fr-CA';
+  if (normalized === 'vi' || normalized.startsWith('vi-')) return 'vi';
+  if (normalized === 'es' || normalized.startsWith('es-')) return 'es';
+  if (normalized === 'hi' || normalized.startsWith('hi-')) return 'hi';
+  if (normalized === 'ar' || normalized.startsWith('ar-')) return 'ar';
+  return 'en';
+}
+
+export type WithI18n<T> = T & {
+  i18n?: { [Key in keyof T]?: T[Key] | null } | null;
+};
+
+/** Overlay translated fields while preserving the English document identity. */
+export function mergeI18nOverlay<T extends object>(row: WithI18n<T>): T {
+  const { i18n, ...base } = row;
+  if (!i18n) return base as unknown as T;
+
+  const overlay = Object.fromEntries(
+    Object.entries(i18n).filter(
+      ([key, value]) =>
+        key !== '_id' &&
+        key !== '_type' &&
+        value !== null &&
+        value !== undefined
+    )
+  ) as Partial<T>;
+
+  return { ...(base as unknown as T), ...overlay };
+}
+
+/** Filter listings to English/legacy docs so translations cannot duplicate rows. */
+export const BASE_LANGUAGE_FILTER = '(language == "en" || !defined(language))';
+
+export const i18nOverlay = (fields: string) =>
+  `"i18n": select($lang != "en" => *[_type == "translation.metadata" && references(^._id)][0].translations[_key == $lang][0].value->{ ${fields} }, null)`;

--- a/unify-front-end/services/sanity/i18n.ts
+++ b/unify-front-end/services/sanity/i18n.ts
@@ -27,22 +27,66 @@ export type WithI18n<T> = T & {
   i18n?: { [Key in keyof T]?: T[Key] | null } | null;
 };
 
-/** Overlay translated fields while preserving the English document identity. */
+const IDENTITY_FIELDS = new Set(['_id', '_type', '_key']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isKeyedItem(value: unknown): value is Record<string, unknown> & {
+  _key: string;
+} {
+  return isRecord(value) && typeof value._key === 'string';
+}
+
+/**
+ * Merge translated data into base content without letting a translation alter
+ * keyed Sanity structure. Base order and `_key`s remain authoritative because
+ * progress, saved answers and resume positions persist those identities.
+ */
+function mergeTranslatedValue(base: unknown, translated: unknown): unknown {
+  if (translated === null || translated === undefined) return base;
+
+  if (Array.isArray(base)) {
+    if (!Array.isArray(translated)) return base;
+    if (base.every(isKeyedItem)) {
+      const translatedByKey = new Map(
+        translated.filter(isKeyedItem).map(item => [item._key, item])
+      );
+      return base.map(item => {
+        const translatedItem = translatedByKey.get(item._key);
+        return translatedItem
+          ? mergeTranslatedValue(item, translatedItem)
+          : item;
+      });
+    }
+    return translated;
+  }
+
+  if (Array.isArray(translated)) return base;
+
+  if (isRecord(base)) {
+    if (!isRecord(translated)) return base;
+    const merged: Record<string, unknown> = { ...base };
+    for (const [key, value] of Object.entries(translated)) {
+      if (IDENTITY_FIELDS.has(key) || value === null || value === undefined) {
+        continue;
+      }
+      merged[key] = mergeTranslatedValue(base[key], value);
+    }
+    return merged;
+  }
+
+  if (isRecord(translated)) return base;
+
+  return translated;
+}
+
+/** Overlay translated fields while preserving all base document identities. */
 export function mergeI18nOverlay<T extends object>(row: WithI18n<T>): T {
   const { i18n, ...base } = row;
   if (!i18n) return base as unknown as T;
-
-  const overlay = Object.fromEntries(
-    Object.entries(i18n).filter(
-      ([key, value]) =>
-        key !== '_id' &&
-        key !== '_type' &&
-        value !== null &&
-        value !== undefined
-    )
-  ) as Partial<T>;
-
-  return { ...(base as unknown as T), ...overlay };
+  return mergeTranslatedValue(base, i18n) as T;
 }
 
 /** Filter listings to English/legacy docs so translations cannot duplicate rows. */

--- a/unify-front-end/services/sanity/lessons.ts
+++ b/unify-front-end/services/sanity/lessons.ts
@@ -1,12 +1,20 @@
 import { sanityClient } from '../../sanity-custom';
 import { SanityLesson } from '../../types/sanity';
+import {
+  BASE_LANGUAGE_FILTER,
+  i18nOverlay,
+  mergeI18nOverlay,
+  type SanityLanguage,
+  type WithI18n,
+} from './i18n';
 
 // Get a single lesson by ID
 export async function getLesson(
-  lessonId: string
+  lessonId: string,
+  language: SanityLanguage = 'en'
 ): Promise<SanityLesson | null> {
   try {
-    const query = `*[_type == "lesson" && _id == $lessonId][0] {
+    const query = `*[_type == "lesson" && _id == $lessonId && ${BASE_LANGUAGE_FILTER}][0] {
       _id,
       _type,
       title,
@@ -16,11 +24,15 @@ export async function getLesson(
       pages,
       activity_pages,
       ending_pages,
-      order
+      order,
+      ${i18nOverlay('title, description, pages, activity_pages, ending_pages')}
     }`;
 
-    const lesson = await sanityClient.fetch(query, { lessonId });
-    return lesson || null;
+    const lesson = await sanityClient.fetch<WithI18n<SanityLesson> | null>(
+      query,
+      { lessonId, lang: language }
+    );
+    return lesson ? mergeI18nOverlay(lesson) : null;
   } catch (error) {
     console.error('Error fetching lesson from Sanity:', error);
     return null;

--- a/unify-front-end/services/sanity/modules.ts
+++ b/unify-front-end/services/sanity/modules.ts
@@ -1,24 +1,62 @@
 import { sanityClient } from '../../sanity-custom';
 import {
   SanityModule,
+  SanityLessonWithQuizzes,
+  SanityQuiz,
   SanitySubmoduleWithLessons,
   SanityModuleWithSubmodules,
 } from '../../types/sanity';
+import {
+  BASE_LANGUAGE_FILTER,
+  i18nOverlay,
+  mergeI18nOverlay,
+  type SanityLanguage,
+  type WithI18n,
+} from './i18n';
+
+type ModuleRow = WithI18n<SanityModule> & {
+  submodules?: (WithI18n<SanitySubmoduleWithLessons> & {
+    lessons?: (WithI18n<SanityLessonWithQuizzes> & {
+      quizzes?: WithI18n<SanityQuiz>[];
+    })[];
+  })[];
+};
+
+function mergeModuleTree(
+  row: ModuleRow
+): SanityModule & { submodules: SanitySubmoduleWithLessons[] } {
+  const module = mergeI18nOverlay(row);
+  return {
+    ...module,
+    submodules: (row.submodules ?? []).map(submodule => ({
+      ...mergeI18nOverlay(submodule),
+      lessons: (submodule.lessons ?? []).map(lesson => ({
+        ...mergeI18nOverlay(lesson),
+        quizzes: (lesson.quizzes ?? []).map(mergeI18nOverlay),
+      })),
+    })),
+  };
+}
 
 // Get all modules
-export async function getAllModules(): Promise<SanityModule[]> {
+export async function getAllModules(
+  language: SanityLanguage = 'en'
+): Promise<SanityModule[]> {
   try {
-    const query = `*[_type == "module"] | order(title) {
+    const query = `*[_type == "module" && ${BASE_LANGUAGE_FILTER}] | order(title) {
       _id,
       _type,
       title,
       description,
       colorTheme { hex },
-      icon
+      icon,
+      ${i18nOverlay('title, description')}
     }`;
 
-    const modules = await sanityClient.fetch(query);
-    return modules || [];
+    const modules = await sanityClient.fetch<WithI18n<SanityModule>[]>(query, {
+      lang: language,
+    });
+    return (modules || []).map(mergeI18nOverlay);
   } catch (error) {
     console.error('Error fetching modules from Sanity:', error);
     return [];
@@ -26,29 +64,33 @@ export async function getAllModules(): Promise<SanityModule[]> {
 }
 
 // Get all modules with their submodules
-export async function getAllModulesWithSubmodules(): Promise<
-  SanityModuleWithSubmodules[]
-> {
+export async function getAllModulesWithSubmodules(
+  language: SanityLanguage = 'en'
+): Promise<SanityModuleWithSubmodules[]> {
   try {
-    const query = `*[_type == "module"] | order(title) {
+    const query = `*[_type == "module" && ${BASE_LANGUAGE_FILTER}] | order(title) {
       _id,
       _type,
       title,
       description,
       colorTheme { hex },
       icon,
-      "submodules": *[_type == "submodule" && references(^._id)] | order(order) {
+      ${i18nOverlay('title, description')},
+      "submodules": *[_type == "submodule" && references(^._id) && ${BASE_LANGUAGE_FILTER}] | order(order) {
         _id,
         _type,
         title,
         description,
         module,
-        order
+        order,
+        ${i18nOverlay('title, description')}
       }
     }`;
 
-    const modules = await sanityClient.fetch(query);
-    return modules || [];
+    const modules = await sanityClient.fetch<ModuleRow[]>(query, {
+      lang: language,
+    });
+    return (modules || []).map(mergeModuleTree);
   } catch (error) {
     console.error('Error fetching modules with submodules from Sanity:', error);
     return [];
@@ -57,20 +99,25 @@ export async function getAllModulesWithSubmodules(): Promise<
 
 // Get a single module by ID
 export async function getModule(
-  moduleId: string
+  moduleId: string,
+  language: SanityLanguage = 'en'
 ): Promise<SanityModule | null> {
   try {
-    const query = `*[_type == "module" && _id == $moduleId][0] {
+    const query = `*[_type == "module" && _id == $moduleId && ${BASE_LANGUAGE_FILTER}][0] {
       _id,
       _type,
       title,
       description,
       colorTheme { hex },
-      icon
+      icon,
+      ${i18nOverlay('title, description')}
     }`;
 
-    const module = await sanityClient.fetch(query, { moduleId });
-    return module || null;
+    const module = await sanityClient.fetch<WithI18n<SanityModule> | null>(
+      query,
+      { moduleId, lang: language }
+    );
+    return module ? mergeI18nOverlay(module) : null;
   } catch (error) {
     console.error('Error fetching module from Sanity:', error);
     return null;
@@ -79,26 +126,29 @@ export async function getModule(
 
 // Get module with all its submodules
 export async function getModuleWithSubmodules(
-  moduleId: string
+  moduleId: string,
+  language: SanityLanguage = 'en'
 ): Promise<
   (SanityModule & { submodules: SanitySubmoduleWithLessons[] }) | null
 > {
   try {
-    const query = `*[_type == "module" && _id == $moduleId][0] {
+    const query = `*[_type == "module" && _id == $moduleId && ${BASE_LANGUAGE_FILTER}][0] {
       _id,
       _type,
       title,
       description,
       colorTheme { hex },
       icon,
-      "submodules": *[_type == "submodule" && references(^._id)] | order(order) {
+      ${i18nOverlay('title, description')},
+      "submodules": *[_type == "submodule" && references(^._id) && ${BASE_LANGUAGE_FILTER}] | order(order) {
         _id,
         _type,
         title,
         description,
         module,
         order,
-        "lessons": *[_type == "lesson" && references(^._id)] | order(order) {
+        ${i18nOverlay('title, description')},
+        "lessons": *[_type == "lesson" && references(^._id) && ${BASE_LANGUAGE_FILTER}] | order(order) {
           _id,
           _type,
           title,
@@ -109,19 +159,24 @@ export async function getModuleWithSubmodules(
           "lesson_page_count": count(pages),
           "activity_page_count": count(activity_pages),
           "ending_page_count": count(ending_pages),
-          "quizzes": *[_type == "quiz" && references(^._id)] | order(order_number) {
+          ${i18nOverlay('title, description')},
+          "quizzes": *[_type == "quiz" && references(^._id) && ${BASE_LANGUAGE_FILTER}] | order(order_number) {
             _id,
             _type,
             title,
             order_number,
-            "question_count": count(questions)
+            "question_count": count(questions),
+            ${i18nOverlay('title')}
           }
         }
       }
     }`;
 
-    const module = await sanityClient.fetch(query, { moduleId });
-    return module || null;
+    const module = await sanityClient.fetch<ModuleRow | null>(query, {
+      moduleId,
+      lang: language,
+    });
+    return module ? mergeModuleTree(module) : null;
   } catch (error) {
     console.error('Error fetching module with submodules from Sanity:', error);
     return null;

--- a/unify-front-end/services/sanity/practices.ts
+++ b/unify-front-end/services/sanity/practices.ts
@@ -1,5 +1,12 @@
 import { sanityClient } from '../../sanity-custom';
 import { SanityPractice } from '../../types/sanity';
+import {
+  BASE_LANGUAGE_FILTER,
+  i18nOverlay,
+  mergeI18nOverlay,
+  type SanityLanguage,
+  type WithI18n,
+} from './i18n';
 
 /** Sanity IDs: alphanumeric, hyphens, underscores; 1–128 chars to prevent GROQ injection. */
 function isValidSanityId(id: string): boolean {
@@ -11,15 +18,7 @@ function isValidSanityId(id: string): boolean {
   );
 }
 
-const PRACTICE_BY_SUBMODULE_QUERY = `*[_type == "practice" && submodule._ref == $submoduleId] | order(order_number asc) {
-  _id,
-  _type,
-  title,
-  description,
-  practice_type,
-  order_number,
-  "submodule": submodule-> { _id, title },
-  questions[] {
+const QUESTION_FIELDS = `questions[] | order(order_number asc) {
     _key,
     question_type,
     question_text,
@@ -28,17 +27,34 @@ const PRACTICE_BY_SUBMODULE_QUERY = `*[_type == "practice" && submodule._ref == 
     correct_answer { value, explanation, points },
     order_number,
     answer_box { content, showAfterSubmit }
-  },
-  pages[] {
+  }`;
+
+const PAGE_FIELDS = `pages[] | order(order asc) {
     _key,
     title,
     order,
-    instructions[],
+    instructions[] {
+      ...,
+      options[] { _key, text, value, is_correct, explanation },
+      matching_pairs[] { _key, left_item, right_item, explanation }
+    },
     answer_box { title, content, showAfterSubmit }
-  }
+  }`;
+
+const PRACTICE_BY_SUBMODULE_QUERY = `*[_type == "practice" && submodule._ref == $submoduleId && ${BASE_LANGUAGE_FILTER}] | order(order_number asc) {
+  _id,
+  _type,
+  title,
+  description,
+  practice_type,
+  order_number,
+  "submodule": submodule-> { _id, title },
+  ${QUESTION_FIELDS},
+  ${PAGE_FIELDS},
+  ${i18nOverlay(`title, description, ${QUESTION_FIELDS}, ${PAGE_FIELDS}`)}
 }`;
 
-const PRACTICE_BY_ID_QUERY = `*[_type == "practice" && _id == $practiceId][0] {
+const PRACTICE_BY_ID_QUERY = `*[_type == "practice" && _id == $practiceId && ${BASE_LANGUAGE_FILTER}][0] {
   _id,
   _type,
   title,
@@ -46,27 +62,14 @@ const PRACTICE_BY_ID_QUERY = `*[_type == "practice" && _id == $practiceId][0] {
   practice_type,
   order_number,
   "submodule": submodule-> { _id, title },
-  questions[] {
-    _key,
-    question_type,
-    question_text,
-    options[] { _key, text, value, is_correct, explanation },
-    matching_pairs[] { _key, left_item, right_item, explanation },
-    correct_answer { value, explanation, points },
-    order_number,
-    answer_box { content, showAfterSubmit }
-  },
-  pages[] {
-    _key,
-    title,
-    order,
-    instructions[],
-    answer_box { title, content, showAfterSubmit }
-  }
+  ${QUESTION_FIELDS},
+  ${PAGE_FIELDS},
+  ${i18nOverlay(`title, description, ${QUESTION_FIELDS}, ${PAGE_FIELDS}`)}
 }`;
 
 export async function getPracticesBySubmodule(
-  submoduleId: string
+  submoduleId: string,
+  language: SanityLanguage = 'en'
 ): Promise<SanityPractice[]> {
   if (!isValidSanityId(submoduleId)) {
     console.warn(
@@ -76,10 +79,14 @@ export async function getPracticesBySubmodule(
     return [];
   }
   try {
-    const result = await sanityClient.fetch(PRACTICE_BY_SUBMODULE_QUERY, {
-      submoduleId,
-    });
-    return Array.isArray(result) ? result : [];
+    const result = await sanityClient.fetch<WithI18n<SanityPractice>[]>(
+      PRACTICE_BY_SUBMODULE_QUERY,
+      {
+        submoduleId,
+        lang: language,
+      }
+    );
+    return Array.isArray(result) ? result.map(mergeI18nOverlay) : [];
   } catch (error) {
     console.error('Error fetching practices by submodule from Sanity:', error);
     return [];
@@ -87,7 +94,8 @@ export async function getPracticesBySubmodule(
 }
 
 export async function getPracticeById(
-  practiceId: string
+  practiceId: string,
+  language: SanityLanguage = 'en'
 ): Promise<SanityPractice | null> {
   if (!isValidSanityId(practiceId)) {
     console.warn(
@@ -97,10 +105,14 @@ export async function getPracticeById(
     return null;
   }
   try {
-    const result = await sanityClient.fetch(PRACTICE_BY_ID_QUERY, {
-      practiceId,
-    });
-    return result && !Array.isArray(result) ? result : null;
+    const result = await sanityClient.fetch<WithI18n<SanityPractice> | null>(
+      PRACTICE_BY_ID_QUERY,
+      {
+        practiceId,
+        lang: language,
+      }
+    );
+    return result && !Array.isArray(result) ? mergeI18nOverlay(result) : null;
   } catch (error) {
     console.error('Error fetching practice by ID from Sanity:', error);
     return null;

--- a/unify-front-end/services/sanity/quizzes.ts
+++ b/unify-front-end/services/sanity/quizzes.ts
@@ -1,5 +1,5 @@
 import { sanityClient } from '../../sanity-custom';
-import { SanityQuiz, SanityQuizQuestion } from '../../types/sanity';
+import { SanityQuiz } from '../../types/sanity';
 import {
   BASE_LANGUAGE_FILTER,
   i18nOverlay,
@@ -51,7 +51,7 @@ export async function getLessonQuizzes(
 export async function getQuizQuestions(
   quizId: string,
   language: SanityLanguage = 'en'
-): Promise<SanityQuizQuestion[]> {
+): Promise<any[]> {
   try {
     const query = `*[_type == "quiz" && _id == $quizId && ${BASE_LANGUAGE_FILTER}][0] {
       ${QUESTION_FIELDS},

--- a/unify-front-end/services/sanity/quizzes.ts
+++ b/unify-front-end/services/sanity/quizzes.ts
@@ -1,23 +1,46 @@
 import { sanityClient } from '../../sanity-custom';
-import { SanityQuiz } from '../../types/sanity';
+import { SanityQuiz, SanityQuizQuestion } from '../../types/sanity';
+import {
+  BASE_LANGUAGE_FILTER,
+  i18nOverlay,
+  mergeI18nOverlay,
+  type SanityLanguage,
+  type WithI18n,
+} from './i18n';
+
+const QUESTION_FIELDS = `questions[] | order(order_number asc) {
+  _key,
+  question_type,
+  question_text,
+  options[] { _key, text, value, is_correct, explanation },
+  matching_pairs[] { _key, left_item, right_item, explanation },
+  correct_answer { value, explanation, points },
+  order_number,
+  answer_box { content, showAfterSubmit }
+}`;
 
 // Get all quizzes for a lesson
 export async function getLessonQuizzes(
-  lessonId: string
+  lessonId: string,
+  language: SanityLanguage = 'en'
 ): Promise<SanityQuiz[]> {
   try {
-    const query = `*[_type == "quiz" && lesson._ref == $lessonId] | order(order_number) {
+    const query = `*[_type == "quiz" && lesson._ref == $lessonId && ${BASE_LANGUAGE_FILTER}] | order(order_number) {
       _id,
       _type,
       title,
       description,
       lesson,
       order_number,
-      questions
+      ${QUESTION_FIELDS},
+      ${i18nOverlay(`title, description, ${QUESTION_FIELDS}`)}
     }`;
 
-    const quizzes = await sanityClient.fetch(query, { lessonId });
-    return quizzes || [];
+    const quizzes = await sanityClient.fetch<WithI18n<SanityQuiz>[]>(query, {
+      lessonId,
+      lang: language,
+    });
+    return (quizzes || []).map(mergeI18nOverlay);
   } catch (error) {
     console.error('Error fetching lesson quizzes from Sanity:', error);
     return [];
@@ -25,12 +48,20 @@ export async function getLessonQuizzes(
 }
 
 // Get quiz questions (questions are embedded in the quiz document)
-export async function getQuizQuestions(quizId: string): Promise<any[]> {
+export async function getQuizQuestions(
+  quizId: string,
+  language: SanityLanguage = 'en'
+): Promise<SanityQuizQuestion[]> {
   try {
-    const query = `*[_type == "quiz" && _id == $quizId][0].questions | order(order_number)`;
+    const query = `*[_type == "quiz" && _id == $quizId && ${BASE_LANGUAGE_FILTER}][0] {
+      ${QUESTION_FIELDS},
+      ${i18nOverlay(QUESTION_FIELDS)}
+    }`;
 
-    const questions = await sanityClient.fetch(query, { quizId });
-    return questions || [];
+    const quiz = await sanityClient.fetch<WithI18n<
+      Pick<SanityQuiz, 'questions'>
+    > | null>(query, { quizId, lang: language });
+    return quiz ? mergeI18nOverlay(quiz).questions || [] : [];
   } catch (error) {
     console.error('Error fetching quiz questions from Sanity:', error);
     return [];

--- a/unify-front-end/services/sanity/quizzes.ts
+++ b/unify-front-end/services/sanity/quizzes.ts
@@ -1,5 +1,5 @@
 import { sanityClient } from '../../sanity-custom';
-import { SanityQuiz } from '../../types/sanity';
+import { SanityQuiz, SanityQuizQuestion } from '../../types/sanity';
 import {
   BASE_LANGUAGE_FILTER,
   i18nOverlay,
@@ -51,7 +51,7 @@ export async function getLessonQuizzes(
 export async function getQuizQuestions(
   quizId: string,
   language: SanityLanguage = 'en'
-): Promise<any[]> {
+): Promise<SanityQuizQuestion[]> {
   try {
     const query = `*[_type == "quiz" && _id == $quizId && ${BASE_LANGUAGE_FILTER}][0] {
       ${QUESTION_FIELDS},

--- a/unify-front-end/services/sanity/submodules.ts
+++ b/unify-front-end/services/sanity/submodules.ts
@@ -1,12 +1,24 @@
 import { sanityClient } from '../../sanity-custom';
 import { SanitySubmodule, SanityLessonWithQuizzes } from '../../types/sanity';
+import {
+  BASE_LANGUAGE_FILTER,
+  i18nOverlay,
+  mergeI18nOverlay,
+  type SanityLanguage,
+  type WithI18n,
+} from './i18n';
+
+type SubmoduleRow = WithI18n<SanitySubmodule> & {
+  lessons?: WithI18n<SanityLessonWithQuizzes>[];
+};
 
 // Get submodule with all its lessons
 export async function getSubmoduleWithLessons(
-  submoduleId: string
+  submoduleId: string,
+  language: SanityLanguage = 'en'
 ): Promise<(SanitySubmodule & { lessons: SanityLessonWithQuizzes[] }) | null> {
   try {
-    const query = `*[_type == "submodule" && _id == $submoduleId][0] {
+    const query = `*[_type == "submodule" && _id == $submoduleId && ${BASE_LANGUAGE_FILTER}][0] {
       _id,
       _type,
       title,
@@ -14,7 +26,8 @@ export async function getSubmoduleWithLessons(
       module,
       intro_pages,
       order,
-      "lessons": *[_type == "lesson" && references(^._id)] | order(order) {
+      ${i18nOverlay('title, description, intro_pages')},
+      "lessons": *[_type == "lesson" && references(^._id) && ${BASE_LANGUAGE_FILTER}] | order(order) {
         _id,
         _type,
         title,
@@ -25,20 +38,30 @@ export async function getSubmoduleWithLessons(
         "lesson_page_count": count(pages),
         "activity_page_count": count(activity_pages),
         "ending_page_count": count(ending_pages),
-        "quizzes": *[_type == "quiz" && references(^._id)] | order(order_number) {
+        ${i18nOverlay('title, description')},
+        "quizzes": *[_type == "quiz" && references(^._id) && ${BASE_LANGUAGE_FILTER}] | order(order_number) {
           _id,
           _type,
           title,
           order_number,
-          "question_count": count(questions)
+          "question_count": count(questions),
+          ${i18nOverlay('title')}
         }
       }
     }`;
 
-    const submodule = await sanityClient.fetch(query, { submoduleId });
+    const submodule = await sanityClient.fetch<SubmoduleRow | null>(query, {
+      submoduleId,
+      lang: language,
+    });
     if (!submodule || Array.isArray(submodule)) return null;
-    return submodule as SanitySubmodule & {
-      lessons: SanityLessonWithQuizzes[];
+    const merged = mergeI18nOverlay(submodule);
+    return {
+      ...merged,
+      lessons: (submodule.lessons ?? []).map(lesson => ({
+        ...mergeI18nOverlay(lesson),
+        quizzes: (lesson.quizzes ?? []).map(mergeI18nOverlay),
+      })),
     };
   } catch (error) {
     console.error('Error fetching submodule with lessons from Sanity:', error);

--- a/unify-front-end/services/sanity/tasks.ts
+++ b/unify-front-end/services/sanity/tasks.ts
@@ -1,8 +1,15 @@
 import { sanityClient } from '../../sanity-custom';
 import { SanityTask } from '../../types/sanity';
+import {
+  BASE_LANGUAGE_FILTER,
+  i18nOverlay,
+  mergeI18nOverlay,
+  type SanityLanguage,
+  type WithI18n,
+} from './i18n';
 
 // Match tasks that reference this submodule (references() catches any ref to submodule doc)
-const TASKS_BY_SUBMODULE_QUERY = `*[_type == "task" && references($submoduleId)] | order(ordering asc) {
+const TASKS_BY_SUBMODULE_QUERY = `*[_type == "task" && references($submoduleId) && ${BASE_LANGUAGE_FILTER}] | order(ordering asc) {
   _id,
   _type,
   _createdAt,
@@ -11,10 +18,11 @@ const TASKS_BY_SUBMODULE_QUERY = `*[_type == "task" && references($submoduleId)]
   title,
   ordering,
   "submodule": submodule,
-  content
+  content,
+  ${i18nOverlay('title, content')}
 }`;
 
-const TASK_BY_ID_QUERY = `*[_type == "task" && _id == $taskId][0] {
+const TASK_BY_ID_QUERY = `*[_type == "task" && _id == $taskId && ${BASE_LANGUAGE_FILTER}][0] {
   _id,
   _type,
   _createdAt,
@@ -23,29 +31,42 @@ const TASK_BY_ID_QUERY = `*[_type == "task" && _id == $taskId][0] {
   title,
   ordering,
   "submodule": submodule,
-  content
+  content,
+  ${i18nOverlay('title, content')}
 }`;
 
 export async function getTasksBySubmodule(
-  submoduleId: string
+  submoduleId: string,
+  language: SanityLanguage = 'en'
 ): Promise<SanityTask[]> {
   try {
-    const result = await sanityClient.fetch(TASKS_BY_SUBMODULE_QUERY, {
-      submoduleId,
-    });
-    return Array.isArray(result) ? result : [];
+    const result = await sanityClient.fetch<WithI18n<SanityTask>[]>(
+      TASKS_BY_SUBMODULE_QUERY,
+      {
+        submoduleId,
+        lang: language,
+      }
+    );
+    return Array.isArray(result) ? result.map(mergeI18nOverlay) : [];
   } catch (error) {
     console.error('Error fetching tasks by submodule from Sanity:', error);
     return [];
   }
 }
 
-export async function getTaskById(taskId: string): Promise<SanityTask | null> {
+export async function getTaskById(
+  taskId: string,
+  language: SanityLanguage = 'en'
+): Promise<SanityTask | null> {
   try {
-    const result = await sanityClient.fetch(TASK_BY_ID_QUERY, {
-      taskId,
-    });
-    return result && !Array.isArray(result) ? result : null;
+    const result = await sanityClient.fetch<WithI18n<SanityTask> | null>(
+      TASK_BY_ID_QUERY,
+      {
+        taskId,
+        lang: language,
+      }
+    );
+    return result && !Array.isArray(result) ? mergeI18nOverlay(result) : null;
   } catch (error) {
     console.error('Error fetching task by id from Sanity:', error);
     return null;

--- a/unify-front-end/types/onboardingProfile.ts
+++ b/unify-front-end/types/onboardingProfile.ts
@@ -43,7 +43,11 @@ export type Hobby =
   | 'food_cooking'
   | 'movies';
 
-export type PreferredLanguage = 'en' | 'vi' | 'es' | 'hi';
+/**
+ * Values another shared-database client may persist. Mobile UI locales remain
+ * the narrower `SupportedLanguage` union until their translations ship.
+ */
+export type PreferredLanguage = 'en' | 'vi' | 'es' | 'hi' | 'ar' | 'fr-CA';
 
 export interface UserOnboardingProfile {
   id: string; // UUID matching auth.users.id

--- a/unify-front-end/utils/checklistTaskCache.ts
+++ b/unify-front-end/utils/checklistTaskCache.ts
@@ -3,6 +3,7 @@ import { UserTaskWithDetails } from '@/types/checklist';
 import type { SanityLanguage } from '@/services/sanity/i18n';
 
 const STORAGE_PREFIX = '@checklist_tasks_v1';
+export const CHECKLIST_CACHE_TTL_MS = 10 * 60 * 1000;
 
 export function buildChecklistCacheStorageKey(
   userId: string,
@@ -16,19 +17,34 @@ export function buildChecklistCacheStorageKey(
   }:${language}`;
 }
 
-const memory = new Map<string, UserTaskWithDetails[]>();
+interface ChecklistCacheEntry {
+  savedAt: number;
+  tasks: UserTaskWithDetails[];
+}
+
+const memory = new Map<string, ChecklistCacheEntry>();
+
+function isFresh(savedAt: number): boolean {
+  return Date.now() - savedAt < CHECKLIST_CACHE_TTL_MS;
+}
 
 export function getChecklistMemoryCache(
   key: string
 ): UserTaskWithDetails[] | undefined {
-  return memory.get(key);
+  const entry = memory.get(key);
+  if (!entry) return undefined;
+  if (!isFresh(entry.savedAt)) {
+    memory.delete(key);
+    return undefined;
+  }
+  return entry.tasks;
 }
 
 export function setChecklistMemoryCache(
   key: string,
   tasks: UserTaskWithDetails[]
 ): void {
-  memory.set(key, tasks);
+  memory.set(key, { tasks, savedAt: Date.now() });
 }
 
 export async function loadChecklistFromDisk(
@@ -39,7 +55,15 @@ export async function loadChecklistFromDisk(
     if (!raw) {
       return null;
     }
-    return JSON.parse(raw) as UserTaskWithDetails[];
+    const parsed = JSON.parse(raw) as Partial<ChecklistCacheEntry>;
+    if (
+      !Array.isArray(parsed.tasks) ||
+      typeof parsed.savedAt !== 'number' ||
+      !isFresh(parsed.savedAt)
+    ) {
+      return null;
+    }
+    return parsed.tasks;
   } catch {
     return null;
   }
@@ -50,8 +74,9 @@ export async function saveChecklistToDisk(
   tasks: UserTaskWithDetails[]
 ): Promise<void> {
   try {
-    memory.set(key, tasks);
-    await AsyncStorage.setItem(key, JSON.stringify(tasks));
+    const entry: ChecklistCacheEntry = { tasks, savedAt: Date.now() };
+    memory.set(key, entry);
+    await AsyncStorage.setItem(key, JSON.stringify(entry));
   } catch (e) {
     console.warn('Failed to persist checklist cache', e);
   }

--- a/unify-front-end/utils/checklistTaskCache.ts
+++ b/unify-front-end/utils/checklistTaskCache.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { UserTaskWithDetails } from '@/types/checklist';
+import type { SanityLanguage } from '@/services/sanity/i18n';
 
 const STORAGE_PREFIX = '@checklist_tasks_v1';
 
@@ -7,11 +8,12 @@ export function buildChecklistCacheStorageKey(
   userId: string,
   stage: number,
   personaSlug: string,
-  stageChanged: boolean
+  stageChanged: boolean,
+  language: SanityLanguage
 ): string {
   return `${STORAGE_PREFIX}:${userId}:${stage}:${personaSlug}:${
     stageChanged ? '1' : '0'
-  }`;
+  }:${language}`;
 }
 
 const memory = new Map<string, UserTaskWithDetails[]>();


### PR DESCRIPTION
## What was done
- Replaced manual GROQ interpolation with the pinned Sanity client, parameterized queries, and published-only reads.
- Added stable-ID translation overlays across Learn, quizzes, practices, tasks, and Checklist while preserving nested progress keys.
- Isolated React Query and persisted Checklist caches by language, with expiry, revalidation, offline retention, and language-race protection.
- Added defensive Arabic and Canadian French profile handling without exposing incomplete mobile locales.
- Added 20 Sanity regression suites and validated TypeScript, i18n, lint, Jest, and iOS/Android exports.